### PR TITLE
Revert "Update workbench due to security patch"

### DIFF
--- a/make.yml
+++ b/make.yml
@@ -266,7 +266,16 @@ projects:
   workbench:
     version: 1.2
   workbench_moderation:
-    version: 3.0
+    version: 1.4
+    patch:
+      # This allows authenticated users to view drafts
+      - https://www.drupal.org/files/workbench_moderation-view-drafts-permission-fix-1461950-8.patch
+      # Without this patch, Behat tests will fail when using fixtures in
+      # combination with Workbench Moderation.
+      - https://www.drupal.org/files/issues/node-deleted-before-shutdown-function-2645622-1.patch
+      # Fixes the issue with the "Generate automatic URL alias" being unchecked
+      # after workbench moderation content is published.
+      - https://www.drupal.org/files/issues/workbench_moderation-pathauto_alias_issue-2308095-20.patch
   #Dev version of WYSIWYG is required for 4.x CKEditor to work.
   workbench_scheduler:
     version: 2.0-beta2


### PR DESCRIPTION
Workbench moderation fundamentally changes how revisions work. Not an acceptable solution for a quick release. 