### PR TITLE
update phing, update guide with correct paths and yaml stuff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "drush/drush":                  "~7.2",
     "phpunit/phpunit":              "4.6.*",
     "squizlabs/php_codesniffer":    "2.*",
-    "phing/phing":                  "dev-master#0ef30e55bb5871cb38903cc0ee9d76074118a22c",
+    "phing/phing":                  "~2.15",
     "jakoch/phantomjs-installer":   "1.9.8",
     "jarnaiz/behat-junit-formatter": "^1.2"
   },

--- a/guides/02-setting-up-development.md
+++ b/guides/02-setting-up-development.md
@@ -12,10 +12,10 @@
   * `composer.lock`
 
 * Modify the following files:
-  * docroot/sites/default/settings/local.settings.php
+  * docroot/sites/default/settings/default.local.settings.php
     * set `port` to `33067`
     * set `base_url` to `https://spyglass.dd:8443`
-  * docroot/sites/hub/settings/local.settings.php
+  * docroot/sites/hub/settings/default.local.settings.php
     * set `port` to `33067`
     * set `base_url` to `https://hub.dd:8443`
 
@@ -25,7 +25,7 @@
     * **local.sites.php**: Uncomment both `$sites` lines; remove `loc.` from each config line.
 
   * `copy tests/behat/example.local.yml tests/behat/local.yml`
-    * **local.yml**: Update default: base_url: https://spyglass.dd:8443 ; Update hub: base_url: https://hub.dd:8443
+    * **local.yml**: Update local: extensions: base_url: https://spyglass.dd:8443 ; Update hub: extensions: Behat\MinkExtension: base_url: https://hub.dd:8443
 
 * In the root of repository:
 ```


### PR DESCRIPTION
:wave: Hey boston.gov people! @jgravois and I both had an [issue with phing](https://gist.github.com/jgravois/954678bb3e84fcd4bef06ba7fa8d76c2) when installing per the dev guide. I also found some inaccuracies with the paths and yaml stuff in the instructions. Take/leave as you see fit!

## Changes

 * Update phing to `~2.15` (this fixed the above symfony/yaml errors, but I leave version decisions to y'all)
 * Correct some paths and yaml inaccuracies in the [dev guide](https://github.com/CityOfBoston/boston.gov/compare/develop...hamhands:develop?expand=1#diff-4dd54f9ffae5cfdfbc2243058ea5ebb0)