### PR TITLE
Issue 244: Add persistent link to Tools in header (hub only)

### DIFF
--- a/docroot/sites/all/themes/custom/boston_hub/src/sass/components/hub-header/_hub-header.scss
+++ b/docroot/sites/all/themes/custom/boston_hub/src/sass/components/hub-header/_hub-header.scss
@@ -105,3 +105,25 @@
   }
 
 }
+
+.logged-in .header-right {
+
+  li[class^="menu-"].first {
+    display: none;
+  }
+
+}
+
+.not-logged-in .header-right {
+
+  li[class^="menu-"] {
+    display: none;
+  }
+
+  li[class^="menu-"].first {
+    display: block;
+  }
+
+
+
+}

--- a/docroot/sites/all/themes/custom/boston_hub/templates/default/page.tpl.php
+++ b/docroot/sites/all/themes/custom/boston_hub/templates/default/page.tpl.php
@@ -48,6 +48,12 @@
       </a>
 
       <div class="header-right">
+        <?php print theme('links__system_secondary_menu', array(
+          'links' => $secondary_menu,
+          'attributes' => array(
+            'class' => array('header-menu', 'links', 'inline', 'clearfix'),
+          ),
+        )); ?>
         <?php if ($logged_in): ?>
           <div class="user_info">
             <input type="checkbox" id="dd__menu__box" class="dd__input">
@@ -78,13 +84,6 @@
               </div>
             </div>
           </div>
-        <?php else: ?>
-          <?php print theme('links__system_secondary_menu', array(
-            'links' => $secondary_menu,
-            'attributes' => array(
-              'class' => array('header-menu', 'links', 'inline', 'clearfix'),
-            ),
-          )); ?>
         <?php endif; ?>
         <?php print render($page['header']); ?>
       </div>


### PR DESCRIPTION
## Changes

 * Moves secondary menu display out of if statement
 * Adds css to hide elements
 * Requires the addition of a new menu item on pre:
 ** Structure -> Menus -> Secondary Menu -> Add Link
 ** Menu Link Title: Tools
 ** Path: tools

This PR references #244