### PR TITLE
Fix issue #591 - grid spacing.

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/views/views-view-unformatted--places--listing.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/views/views-view-unformatted--places--listing.tpl.php
@@ -7,7 +7,7 @@
  * @ingroup views_templates
  */
 ?>
-<div class="g">
+<div class="g p-b500">
   <?php foreach ($rows as $id => $row): ?>
     <?php print $row; ?>
   <?php endforeach; ?>


### PR DESCRIPTION
I believe the pattern library will need to be updated to accommodate the p-b500 class.

```
.p-b500 {
    padding-bottom: 27.56px;
    padding-bottom: 1.7225rem;
}
```