### PR TITLE
[Hotfix] Disable query rewrite for Upcoming Events view.

### DIFF
--- a/docroot/sites/all/modules/features/bos_view_upcoming_events/bos_view_upcoming_events.info
+++ b/docroot/sites/all/modules/features/bos_view_upcoming_events/bos_view_upcoming_events.info
@@ -8,4 +8,4 @@ dependencies[] = views
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[views_view][] = upcoming_events
-mtime = 1493822292
+mtime = 1494446384

--- a/docroot/sites/all/modules/features/bos_view_upcoming_events/bos_view_upcoming_events.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_upcoming_events/bos_view_upcoming_events.views_default.inc
@@ -27,6 +27,7 @@ function bos_view_upcoming_events_views_default_views() {
   $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
   $handler->display->display_options['query']['options']['distinct'] = TRUE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'some';


### PR DESCRIPTION
Allow non-admin users to see upcoming events display. Removes node_access on relationships.