### PR TITLE
Fix issue #666: Add Security Questions to user menu.

### DIFF
--- a/docroot/sites/all/themes/custom/boston_hub/template.php
+++ b/docroot/sites/all/themes/custom/boston_hub/template.php
@@ -59,6 +59,7 @@ function boston_hub_preprocess_page(array &$variables) {
 
     $variables['profile_path'] = base_path() . 'my-profile';
     $variables['logout_path'] = base_path() . 'user/logout';
+    $variables['security_questions_path'] = 'https://oimprd.cityofboston.gov/admin/faces/pages/pwdmgmt.jspx?action=setchallenges&backUrl=';
     $variables['change_password_path'] = 'https://oimprd.cityofboston.gov/admin/faces/pages/pwdmgmt.jspx?backUrl=https%3A%2F%2Foif.cityofboston.gov%2Ffed%2Fidp%2Finitiatesso%3Fproviderid%3Dthehubprod';
   }
 

--- a/docroot/sites/all/themes/custom/boston_hub/templates/default/page.tpl.php
+++ b/docroot/sites/all/themes/custom/boston_hub/templates/default/page.tpl.php
@@ -82,6 +82,11 @@
                     </a>
                   </li>
                   <li>
+                    <a href="<?php print $security_questions_path; ?>" title="Security questions">
+                      Security questions
+                    </a>
+                  </li>
+                  <li>
                     <a href="<?php print $logout_path; ?>" title="log out">
                       Log Out
                     </a>


### PR DESCRIPTION
Updates:
- sites/all/themes/custom/boston_hub/template.php
  - Adds new variable via `hook_preprocess_page()`
- sites/all/themes/custom/boston_hub/templates/default/page.tpl.php
  - Adds `<li>` to menu-user for display