### PR TITLE
Fix Issue 685 - Citywide for field_multiple_neighborhoods

### DIFF
--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -627,3 +627,13 @@ function bos_profile_update_7025() {
   );
   module_enable($enabled_modules);
 }
+
+/**
+ * Update for 6/5/17
+ */
+function bos_profile_update_7026() {
+  $enabled_modules = array(
+    'bos_form_citywide_neighborhood',
+  );
+  module_enable($enabled_modules);
+}

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.info
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.info
@@ -1,0 +1,4 @@
+name = Boston Form Citywide Neighborhood
+description = Adds a "citywide" option to field_multiple_neighborhoods.
+package = Boston Custom
+core = 7.x

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
@@ -11,16 +11,24 @@
 function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_id) {
   // Make sure we're on an Event, Post, or Public Notice form.
   if (($form_id == "event_node_form") || ($form_id == "post_node_form") || ($form_id == "notice_node_form")) {
-    // Create a new checkbox call 'Citywide'.
-    $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options']['citywide'] = 'Citywide';
-    // Set the weight so the 'Citywide' option appears at the top of the list.
-    $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['citywide']['#weight'] = -99;
+    $test = $form['field_multiple_neighborhoods'];
     // Loop through every Neighborhood checkbox.
+    foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
+      if ($name == 'Citywide') {
+        // Set the weight so the 'Citywide' option appears at top of the list.
+        $form['field_multiple_neighborhoods'][LANGUAGE_NONE][$tid]['#weight'] = -99;
+        // Get the Term ID for the citywide taxonomy term.
+        $citywide_tid = $tid;
+        // Get "name" attr for Citywide checkbox used to tick other checkboxes.
+        $citywide_input = "field_multiple_neighborhoods[und][$citywide_tid]";
+      }
+    }
+    // Loop through every Neighborhood checkbox again.
     foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
       // Set a state for all checkbox based on 'Citywide' value.
       $form['field_multiple_neighborhoods'][LANGUAGE_NONE][$tid]['#states'] = array(
         'checked' => array(
-          ':input[name="field_multiple_neighborhoods[und][citywide]"]' => array('checked' => TRUE),
+          ':input[name="' . $citywide_input . '"]' => array('checked' => TRUE),
         ),
       );
     }
@@ -40,13 +48,28 @@ function bos_form_citywide_neighborhood_page_build(&$page) {
   $bundle = $page['content']['system_main']['nodes'][$nid]['#bundle'];
   // Make sure we only run this code on certain content types.
   if ($bundle == 'event' || $bundle == 'post' || $bundle == 'notice') {
-    if (FALSE) { // Needs to look for 'citywide value'
-      $neighborhoods = $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'];
+    // Get details about field_multiple_neighborhoods for current node.
+    $neighborhoods = $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'];
+    // Assume 'Citywide' is not set by default.
+    $is_citywide = FALSE;
+    // Loop through all attributes for this field.
+    foreach ($neighborhoods as $key => $neighborhood) {
+      // Check if 'Citywide' has been saved for node.
+      if (is_numeric($key) && $neighborhood['#markup'] == 'Citywide') {
+        // 'Citywide' is found.
+        $is_citywide = TRUE;
+      }
+    }
+    // Remove other neighborhoods from display if 'Citywide' was found.
+    if ($is_citywide) {
       foreach ($neighborhoods as $key => $neighborhood) {
+        // Make sure you're not running logic on attributes that aren't terms.
         if (is_numeric($key)) {
+          // Remove term so it does not display.
           unset($page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][$key]);
         }
       }
+      // Re-add the 'Citywide' markup so it is the only neighborhood displayed.
       $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][0]['#markup'] = 'Citywide';
     }
   }

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Adds "citywide" option to field_multiple_neighborhoods.
+ */
+
+/**
+ * Implements form_alter().
+ */
+function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_id) {
+  if (($form_id == "event_node_form") || ($form_id == "post_node_form") || ($form_id == "notice_node_form")) {
+    $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options']['citywide'] = 'Citywide';
+    //$form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#states'] = array(
+    $form['field_multiple_neighborhoods'][LANGUAGE_NONE][251]['#states'] = array(
+      //'disabled' => array(
+      'checked' => array(
+        //':input[name="field_multiple_neighborhoods[und][citywide]"]' => array('checked' => TRUE),
+        ':input[name="field_phone_number[und][0][value]"]' => array('filled' => TRUE),
+      ),
+    );
+  }
+}

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
@@ -15,17 +15,15 @@ function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_i
     $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options']['citywide'] = 'Citywide';
     // Set the weight so the 'Citywide' option appears at the top of the list.
     $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['citywide']['#weight'] = -99;
-    $default_options = $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'];
     // Loop through every Neighborhood checkbox.
     foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
-      // Set a state that checks all checkbox is 'Citywide' is checked.
+      // Set a state for all checkbox based on 'Citywide' value.
       $form['field_multiple_neighborhoods'][LANGUAGE_NONE][$tid]['#states'] = array(
         'checked' => array(
           ':input[name="field_multiple_neighborhoods[und][citywide]"]' => array('checked' => TRUE),
         ),
       );
     }
-    $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] = $default_options;
   }
 }
 
@@ -33,27 +31,23 @@ function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_i
  * Implements hook_page_build().
  */
 function bos_form_citywide_neighborhood_page_build(&$page) {
+  // Load the node we're on.
   if ($node = menu_get_object()) {
+    // Get the node ID.
     $nid = $node->nid;
   }
-  $bundle = $page['content']['system_main']['nodes'][26385]['#bundle'];
-  if ($bundle && $nid && ($bundle == 'event' || $bundle == 'post' || $bundle == 'notice')) {
-    $neighborhoods = $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'];
-    foreach ($neighborhoods as $key => $neighborhood) {
-      if (is_numeric($key)) {
-        unset($page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][$key]);
-        //$page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][$key]['#markup'] = '';
+  // Get the content type.
+  $bundle = $page['content']['system_main']['nodes'][$nid]['#bundle'];
+  // Make sure we only run this code on certain content types.
+  if ($bundle == 'event' || $bundle == 'post' || $bundle == 'notice') {
+    if (FALSE) { // Needs to look for 'citywide value'
+      $neighborhoods = $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'];
+      foreach ($neighborhoods as $key => $neighborhood) {
+        if (is_numeric($key)) {
+          unset($page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][$key]);
+        }
       }
+      $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][0]['#markup'] = 'Citywide';
     }
-    $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][0]['#markup'] = 'Citywide';
   }
-}
-
-/**
- * Implements hook_page_alter().
- */
-function bos_form_citywide_neighborhood_page_alter(&$page) {
-  $test = $page;
-  $test2 = $page['content']['system_main']['nodes'][26385]['field_multiple_neighborhoods'];
-  $beacon_hill = $page['content']['system_main']['nodes'][26385]['field_multiple_neighborhoods'][3];
 }

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
@@ -9,15 +9,20 @@
  * Implements form_alter().
  */
 function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_id) {
+  // Make sure we're on an Event, Post, or Public Notice form.
   if (($form_id == "event_node_form") || ($form_id == "post_node_form") || ($form_id == "notice_node_form")) {
+    // Create a new checkbox call 'Citywide'.
     $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options']['citywide'] = 'Citywide';
-    //$form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#states'] = array(
-    $form['field_multiple_neighborhoods'][LANGUAGE_NONE][251]['#states'] = array(
-      //'disabled' => array(
-      'checked' => array(
-        //':input[name="field_multiple_neighborhoods[und][citywide]"]' => array('checked' => TRUE),
-        ':input[name="field_phone_number[und][0][value]"]' => array('filled' => TRUE),
-      ),
-    );
+    // Set the weight so the 'Citywide' option appears at the top of the list.
+    $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['citywide']['#weight'] = -99;
+    // Loop through every Neighborhood checkbox.
+    foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
+      // Set a state that checks all checkbox is 'Citywide' is checked.
+      $form['field_multiple_neighborhoods'][LANGUAGE_NONE][$tid]['#states'] = array(
+        'checked' => array(
+          ':input[name="field_multiple_neighborhoods[und][citywide]"]' => array('checked' => TRUE),
+        ),
+      );
+    }
   }
 }

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
@@ -15,6 +15,7 @@ function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_i
     $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options']['citywide'] = 'Citywide';
     // Set the weight so the 'Citywide' option appears at the top of the list.
     $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['citywide']['#weight'] = -99;
+    $default_options = $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'];
     // Loop through every Neighborhood checkbox.
     foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
       // Set a state that checks all checkbox is 'Citywide' is checked.
@@ -24,5 +25,35 @@ function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_i
         ),
       );
     }
+    $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] = $default_options;
   }
+}
+
+/**
+ * Implements hook_page_build().
+ */
+function bos_form_citywide_neighborhood_page_build(&$page) {
+  if ($node = menu_get_object()) {
+    $nid = $node->nid;
+  }
+  $bundle = $page['content']['system_main']['nodes'][26385]['#bundle'];
+  if ($bundle && $nid && ($bundle == 'event' || $bundle == 'post' || $bundle == 'notice')) {
+    $neighborhoods = $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'];
+    foreach ($neighborhoods as $key => $neighborhood) {
+      if (is_numeric($key)) {
+        unset($page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][$key]);
+        //$page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][$key]['#markup'] = '';
+      }
+    }
+    $page['content']['system_main']['nodes'][$nid]['field_multiple_neighborhoods'][0]['#markup'] = 'Citywide';
+  }
+}
+
+/**
+ * Implements hook_page_alter().
+ */
+function bos_form_citywide_neighborhood_page_alter(&$page) {
+  $test = $page;
+  $test2 = $page['content']['system_main']['nodes'][26385]['field_multiple_neighborhoods'];
+  $beacon_hill = $page['content']['system_main']['nodes'][26385]['field_multiple_neighborhoods'][3];
 }

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
@@ -11,7 +11,10 @@
 function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_id) {
   // Make sure we're on an Event, Post, or Public Notice form.
   if (($form_id == "event_node_form") || ($form_id == "post_node_form") || ($form_id == "notice_node_form")) {
-    $test = $form['field_multiple_neighborhoods'];
+    //foreach ($form['field_multiple_neighborhoods']['und']['#entity']->field_multiple_neighborhoods['und'] as $option) {
+    //  $enabled_tid = $option['target_id'];
+    //}
+    $enabled_tids = $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#entity']->field_multiple_neighborhoods['und'];
     // Loop through every Neighborhood checkbox.
     foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
       if ($name == 'Citywide') {
@@ -29,6 +32,9 @@ function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_i
       $form['field_multiple_neighborhoods'][LANGUAGE_NONE][$tid]['#states'] = array(
         'checked' => array(
           ':input[name="' . $citywide_input . '"]' => array('checked' => TRUE),
+        ),
+        'unchecked' => array(
+          ':input[name="field_multiple_neighborhoods[und][' . $tid . ']"]' => array('checked' => FALSE),
         ),
       );
     }

--- a/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
+++ b/docroot/sites/all/modules/custom/bos_form_citywide_neighborhood/bos_form_citywide_neighborhood.module
@@ -11,10 +11,6 @@
 function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_id) {
   // Make sure we're on an Event, Post, or Public Notice form.
   if (($form_id == "event_node_form") || ($form_id == "post_node_form") || ($form_id == "notice_node_form")) {
-    //foreach ($form['field_multiple_neighborhoods']['und']['#entity']->field_multiple_neighborhoods['und'] as $option) {
-    //  $enabled_tid = $option['target_id'];
-    //}
-    $enabled_tids = $form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#entity']->field_multiple_neighborhoods['und'];
     // Loop through every Neighborhood checkbox.
     foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
       if ($name == 'Citywide') {
@@ -30,9 +26,11 @@ function bos_form_citywide_neighborhood_form_alter(&$form, &$form_state, $form_i
     foreach ($form['field_multiple_neighborhoods'][LANGUAGE_NONE]['#options'] as $tid => $name) {
       // Set a state for all checkbox based on 'Citywide' value.
       $form['field_multiple_neighborhoods'][LANGUAGE_NONE][$tid]['#states'] = array(
+        // Check/uncheck all checkboxes based on 'Citywide' value.
         'checked' => array(
           ':input[name="' . $citywide_input . '"]' => array('checked' => TRUE),
         ),
+        // Allow enabled checkboxes from db to be checked on page load.
         'unchecked' => array(
           ':input[name="field_multiple_neighborhoods[und][' . $tid . ']"]' => array('checked' => FALSE),
         ),


### PR DESCRIPTION
Adds a custom module that:
1. Does a hook_form_alter() to select all/none checkboxes
2. Does a hook_page_build() to update the node display to only display 'Citywide' if all options are selected. Should still allow filters on pages like /events to work as previously design (e.g. If 'Citywide' is selected, you should be able to use 'Allston' as the filter criteria and the Event should still show up).
 
**Note:** This fix requires a content change: We need to add a taxonomy term called 'Citywide' to the Neighborhoods vocabulary (/admin/structure/taxonomy/neighborhoods).
