### PR TITLE
Adds lo-abs to app logo to center w/o flexbox

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/page/page--api--v1--layouts--app.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/page/page--api--v1--layouts--app.tpl.php
@@ -27,7 +27,7 @@
         <span class="brg-t"><span class="a11y--h">Toggle </span>Menu</span>
       </div>
     </label>
-    <div class="lo">
+    <div class="lo lo--abs">
       <a href="https://www.boston.gov" class="lo-l">
         <img src="<?php print $asset_url ?>/images/public/logo.svg" alt="City of Boston" class="lo-i" />
         <span class="lo-t">Mayor Martin J. Walsh</span>


### PR DESCRIPTION
Necessary for IE9 headers looking reasonable.