### PR TITLE
Make testimony time blank by default on public notices.

### DIFF
--- a/docroot/sites/all/modules/features/bos_content_type_public_notice/bos_content_type_public_notice.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/bos_content_type_public_notice/bos_content_type_public_notice.features.field_instance.inc
@@ -1780,7 +1780,7 @@ function bos_content_type_public_notice_field_default_field_instances() {
     'label' => 'Time public testimony begins',
     'required' => 0,
     'settings' => array(
-      'default_value' => 'now',
+      'default_value' => 'blank',
       'default_value2' => 'same',
       'default_value_code' => '',
       'default_value_code2' => '',
@@ -1791,7 +1791,7 @@ function bos_content_type_public_notice_field_default_field_instances() {
       'module' => 'date',
       'settings' => array(
         'increment' => 1,
-        'input_format' => 'g:i:sa',
+        'input_format' => 'site-wide',
         'input_format_custom' => '',
         'label_position' => 'above',
         'no_fieldset' => 0,

--- a/docroot/sites/all/modules/features/bos_content_type_public_notice/bos_content_type_public_notice.info
+++ b/docroot/sites/all/modules/features/bos_content_type_public_notice/bos_content_type_public_notice.info
@@ -77,4 +77,4 @@ features[variable][] = node_submitted_public_notice
 features[variable][] = pathauto_node_public_notice_pattern
 features[variable][] = xmlsitemap_settings_node_public_notice
 features_exclude[field_instance][node-public_notice-field_components] = node-public_notice-field_components
-mtime = 1496147504
+mtime = 1496862136


### PR DESCRIPTION
Changed the default value for "Time public testimony begins" from "now" to "blank" and updated the bos_content_type_public_notice feature.