### PR TITLE
Issue 695 - Limit featured event list to only future events

### DIFF
--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -652,3 +652,13 @@ function bos_profile_update_7027() {
   );
   module_enable($enabled_modules);
 }
+
+/**
+ * Update for 6/28/17
+ */
+function bos_profile_update_7028() {
+  $enabled_modules = array(
+    'bos_view_upcoming_events_featured_event_filter',
+  );
+  module_enable($enabled_modules);
+}

--- a/docroot/sites/all/modules/features/bos_shared_fields/bos_shared_fields.features.field_base.inc
+++ b/docroot/sites/all/modules/features/bos_shared_fields/bos_shared_fields.features.field_base.inc
@@ -837,21 +837,17 @@ function bos_shared_fields_field_default_field_bases() {
     'locked' => 0,
     'module' => 'entityreference',
     'settings' => array(
-      'handler' => 'base',
+      'handler' => 'views',
       'handler_settings' => array(
         'behaviors' => array(
           'views-select-list' => array(
             'status' => 0,
           ),
         ),
-        'sort' => array(
-          'direction' => 'ASC',
-          'property' => 'title',
-          'type' => 'property',
-        ),
-        'target_bundles' => array(
-          'event' => 'event',
-          'public_notice' => 'public_notice',
+        'view' => array(
+          'args' => array(),
+          'display_name' => 'entityreference_1',
+          'view_name' => 'upcoming_events_featured_event_filter',
         ),
       ),
       'target_type' => 'node',

--- a/docroot/sites/all/modules/features/bos_shared_fields/bos_shared_fields.info
+++ b/docroot/sites/all/modules/features/bos_shared_fields/bos_shared_fields.info
@@ -122,4 +122,4 @@ features[field_base][] = field_type_of_content
 features[field_base][] = field_updated_date
 features[field_base][] = field_vote_button_text
 features[field_base][] = field_year_elected
-mtime = 1493142136
+mtime = 1496862136

--- a/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.features.inc
+++ b/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.features.inc
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * bos_view_upcoming_events_featured_event_filter.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function bos_view_upcoming_events_featured_event_filter_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.info
+++ b/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.info
@@ -1,0 +1,12 @@
+name = Boston View Upcoming Events - Featured Event Filter
+description = Used as an option limit for field_featured_item entity reference field used in upcoming_events paragraph/component
+core = 7.x
+package = Features
+version = 7.x-1.0
+project = bos_view_upcoming_events_featured_event_filter
+dependencies[] = entityreference
+dependencies[] = views
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[views_view][] = upcoming_events_featured_event_filter
+features_exclude[dependencies][ctools] = ctools

--- a/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.module
+++ b/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the Boston View Upcoming Events - Featured Event Filter feature.
+ */
+
+include_once 'bos_view_upcoming_events_featured_event_filter.features.inc';

--- a/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_upcoming_events_featured_event_filter/bos_view_upcoming_events_featured_event_filter.views_default.inc
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @file
+ * bos_view_upcoming_events_featured_event_filter.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function bos_view_upcoming_events_featured_event_filter_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'upcoming_events_featured_event_filter';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'Upcoming Events - Featured Event Filter';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['style_plugin'] = 'default';
+  $handler->display->display_options['row_plugin'] = 'fields';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Sort criterion: Content: Title */
+  $handler->display->display_options['sorts']['title']['id'] = 'title';
+  $handler->display->display_options['sorts']['title']['table'] = 'node';
+  $handler->display->display_options['sorts']['title']['field'] = 'title';
+  $handler->display->display_options['sorts']['title']['order'] = 'DESC';
+  $handler->display->display_options['filter_groups']['groups'] = array(
+    1 => 'AND',
+    2 => 'OR',
+  );
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'event' => 'event',
+    'public_notice' => 'public_notice',
+  );
+  $handler->display->display_options['filters']['type']['group'] = 1;
+  /* Filter criterion: Content: Event Dates -  start date (field_event_dates) */
+  $handler->display->display_options['filters']['field_event_dates_value']['id'] = 'field_event_dates_value';
+  $handler->display->display_options['filters']['field_event_dates_value']['table'] = 'field_data_field_event_dates';
+  $handler->display->display_options['filters']['field_event_dates_value']['field'] = 'field_event_dates_value';
+  $handler->display->display_options['filters']['field_event_dates_value']['operator'] = '>=';
+  $handler->display->display_options['filters']['field_event_dates_value']['group'] = 2;
+  $handler->display->display_options['filters']['field_event_dates_value']['default_date'] = 'now';
+  /* Filter criterion: Content: Date -  start date (field_public_notice_date) */
+  $handler->display->display_options['filters']['field_public_notice_date_value']['id'] = 'field_public_notice_date_value';
+  $handler->display->display_options['filters']['field_public_notice_date_value']['table'] = 'field_data_field_public_notice_date';
+  $handler->display->display_options['filters']['field_public_notice_date_value']['field'] = 'field_public_notice_date_value';
+  $handler->display->display_options['filters']['field_public_notice_date_value']['operator'] = '>=';
+  $handler->display->display_options['filters']['field_public_notice_date_value']['group'] = 2;
+  $handler->display->display_options['filters']['field_public_notice_date_value']['default_date'] = 'now';
+
+  /* Display: Entity Reference */
+  $handler = $view->new_display('entityreference', 'Entity Reference', 'entityreference_1');
+  $handler->display->display_options['defaults']['title'] = FALSE;
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['defaults']['style_plugin'] = FALSE;
+  $handler->display->display_options['style_plugin'] = 'entityreference_style';
+  $handler->display->display_options['style_options']['search_fields'] = array(
+    'title' => 'title',
+  );
+  $handler->display->display_options['defaults']['style_options'] = FALSE;
+  $handler->display->display_options['defaults']['row_plugin'] = FALSE;
+  $handler->display->display_options['row_plugin'] = 'entityreference_fields';
+  $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $export['upcoming_events_featured_event_filter'] = $view;
+
+  return $export;
+}


### PR DESCRIPTION
Adds a feature for a view that limits the options in the entity reference field: sites/all/modules/features/bos_view_upcoming_events_featured_event_filter

Updates the entity selection value for field_featured_item via the sites/all/modules/features/bos_shared_fields feature