### PR TITLE
Issue 679 - Expand all drawers to allow "ctrl + f" browser searching

### DIFF
--- a/docroot/sites/all/themes/custom/boston/src/js/drawer.js
+++ b/docroot/sites/all/themes/custom/boston/src/js/drawer.js
@@ -48,20 +48,46 @@
     });
   }
 
-  // Expand drawers when user searchs page with CTRL+f
-  var expanded;
+  // Expand drawers so users can search within them easily.
   $(document).on("keydown", function (e) {
-    if (e.keyCode == 70 && e.ctrlKey && !expanded) {
-      $('.dr-h').click();
-      expanded = true;
+    // Check for CTRL+f input.
+    if (e.keyCode == 70 && e.ctrlKey) {
+      // Loop through each label that controls a hidden checkbox.
+      $('.dr-h').each(function() {
+        // Only execute on drawers that are closed.
+        if (!$(this).hasClass('expanded')) {
+          // Simulate a click on the drawer label to open it.
+          $(this).click();
+          // Add a class so we know this drawer is now open.
+          $(this).addClass('expanded');
+        }
+      });
     }
-    if (e.keyCode == 27 && expanded) {
-      $('.dr-tr').attr('checked', false);
-      expanded = false;
+    // Check for ESC input.
+    if (e.keyCode == 27) {
+      // Loop through each label that controls a hidden checkbox.
+      $('.dr-h').each(function() {
+        // Only execute on drawers that are open.
+        if ($(this).hasClass('expanded')) {
+          // Simulate a click on the drawer label to close it.
+          $(this).click();
+          // Remove a class so we know this drawer is now closed.
+          $(this).removeClass('expanded');
+        }
+      });
     }
   });
-  $('label.dr-h').click(function() {
-    expanded = false;
+  // Check for clicks outside of browser search.
+  $('.dr-h').click(function() {
+    // Check if the clicked drawer is already open.
+    if ($(this).hasClass('expanded')) {
+      // Remove the class so we know this drawer was closed manually.
+      $(this).removeClass('expanded');
+    // If the drawer is closed already.
+    } else {
+      // Add a class so we know if was just opened.
+      $(this).addClass('expanded');
+    }
   });
 
 })(jQuery, Drupal, this, this.document);

--- a/docroot/sites/all/themes/custom/boston/src/js/drawer.js
+++ b/docroot/sites/all/themes/custom/boston/src/js/drawer.js
@@ -48,4 +48,13 @@
     });
   }
 
+  // Expand drawers when user searchs page with CTRL+F
+  $(document).on("keydown", function (e) {
+    if (e.keyCode == 70 && e.ctrlKey) {
+      //$('.drawer-trigger').toggleClass('active').next('.drawer').toggleClass('active').slideDown(400);
+      //$('.dr-tr').prop('checked', true);
+      $('.dr-tr').attr('checked', true);
+    }
+  });
+
 })(jQuery, Drupal, this, this.document);

--- a/docroot/sites/all/themes/custom/boston/src/js/drawer.js
+++ b/docroot/sites/all/themes/custom/boston/src/js/drawer.js
@@ -51,9 +51,12 @@
   // Expand drawers when user searchs page with CTRL+F
   $(document).on("keydown", function (e) {
     if (e.keyCode == 70 && e.ctrlKey) {
-      //$('.drawer-trigger').toggleClass('active').next('.drawer').toggleClass('active').slideDown(400);
-      //$('.dr-tr').prop('checked', true);
-      $('.dr-tr').attr('checked', true);
+      $('.dr-h').click();
+      //$('.dr-tr').attr('checked', true);
+      console.log("Search!");
+    }
+    if (e.keyCode == 27) {
+      //$('.dr-tr').attr('checked', false);
     }
   });
 

--- a/docroot/sites/all/themes/custom/boston/src/js/drawer.js
+++ b/docroot/sites/all/themes/custom/boston/src/js/drawer.js
@@ -48,16 +48,20 @@
     });
   }
 
-  // Expand drawers when user searchs page with CTRL+F
+  // Expand drawers when user searchs page with CTRL+f
+  var expanded;
   $(document).on("keydown", function (e) {
-    if (e.keyCode == 70 && e.ctrlKey) {
+    if (e.keyCode == 70 && e.ctrlKey && !expanded) {
       $('.dr-h').click();
-      //$('.dr-tr').attr('checked', true);
-      console.log("Search!");
+      expanded = true;
     }
-    if (e.keyCode == 27) {
-      //$('.dr-tr').attr('checked', false);
+    if (e.keyCode == 27 && expanded) {
+      $('.dr-tr').attr('checked', false);
+      expanded = false;
     }
+  });
+  $('label.dr-h').click(function() {
+    expanded = false;
   });
 
 })(jQuery, Drupal, this, this.document);


### PR DESCRIPTION
Modified `sites/all/themes/custom/boston/src/js/drawer.js` (where search bar logic is), so not sure this is the right place. Should this go in fractal?