### PR TITLE
Issue 753 - Fix details link Title and URL for Events

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/node/node--event.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/node/node--event.tpl.php
@@ -104,7 +104,7 @@ hide($content['links']);
       <?php endif; ?>
       <?php if (isset($content['field_details_link'])): ?>
         <div class="external-link external-link--inline">
-          <a class="button" href="<?php print render($content['field_details_link']); ?>">
+          <a class="button" href="<?php print render($field_details_link[0]['url']); ?>">
             <?php print render($field_details_link[0]['title']); ?>
             <span class="a11y--hidden"> for <?php print $title; ?></span>
           </a>

--- a/docroot/sites/all/themes/custom/boston/templates/node/node--event.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/node/node--event.tpl.php
@@ -104,7 +104,10 @@ hide($content['links']);
       <?php endif; ?>
       <?php if (isset($content['field_details_link'])): ?>
         <div class="external-link external-link--inline">
-          <a class="button" href="<?php print render($content['field_details_link']); ?>">Event website<span class="a11y--hidden"> for <?php print $title; ?></span></a>
+          <a class="button" href="<?php print render($content['field_details_link']); ?>">
+            <?php print render($field_details_link[0]['title']); ?>
+            <span class="a11y--hidden"> for <?php print $title; ?></span>
+          </a>
         </div>
       <?php endif; ?>
     </div>


### PR DESCRIPTION
Updates event template (`sites/all/themes/custom/boston/templates/node/node--event.tpl.php`) to use simple field values for URL and Title. 

The previous code is also found in notices template (`sites/all/themes/custom/boston/templates/node/node--public-notice.tpl.php`), however this content type does not seem to have `field_details_link`.