### PR TITLE
Fix Issue 545 - Remove white space at top of program/initiative view.

### DIFF
--- a/docroot/sites/all/themes/custom/boston/src/sass/components/components/_list_component.scss
+++ b/docroot/sites/all/themes/custom/boston/src/sass/components/components/_list_component.scss
@@ -2,5 +2,6 @@
   &.view-places-listing,
   &.view-program-initiatives-listing {
     background-color: color(section-bg);
+    overflow: hidden;
   }
 }


### PR DESCRIPTION
Adds SCSS to boston, which I know we're trying to avoid. Figured it might be ok since it's a single line bug fix.

@matthewcrist would you rather that we look into creating a fractal component here?