### PR TITLE
Issue 10 revised - No results behavior

### DIFF
--- a/docroot/sites/all/modules/features/bos_content_type_how_to/bos_content_type_how_to.features.field_base.inc
+++ b/docroot/sites/all/modules/features/bos_content_type_how_to/bos_content_type_how_to.features.field_base.inc
@@ -10,14 +10,13 @@
 function bos_content_type_how_to_field_default_field_bases() {
   $field_bases = array();
 
-  // Exported field_base: 'field_how_to_steps'
+  // Exported field_base: 'field_how_to_steps'.
   $field_bases['field_how_to_steps'] = array(
     'active' => 1,
     'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_how_to_steps',
-    'foreign keys' => array(),
     'indexes' => array(),
     'locked' => 0,
     'module' => 'paragraphs',
@@ -26,14 +25,13 @@ function bos_content_type_how_to_field_default_field_bases() {
     'type' => 'paragraphs',
   );
 
-  // Exported field_base: 'field_how_to_tabs'
+  // Exported field_base: 'field_how_to_tabs'.
   $field_bases['field_how_to_tabs'] = array(
     'active' => 1,
     'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_how_to_tabs',
-    'foreign keys' => array(),
     'indexes' => array(),
     'locked' => 0,
     'module' => 'paragraphs',
@@ -42,21 +40,13 @@ function bos_content_type_how_to_field_default_field_bases() {
     'type' => 'paragraphs',
   );
 
-  // Exported field_base: 'field_how_to_title'
+  // Exported field_base: 'field_how_to_title'.
   $field_bases['field_how_to_title'] = array(
     'active' => 1,
     'cardinality' => 1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_how_to_title',
-    'foreign keys' => array(
-      'format' => array(
-        'columns' => array(
-          'format' => 'format',
-        ),
-        'table' => 'filter_format',
-      ),
-    ),
     'indexes' => array(
       'format' => array(
         0 => 'format',
@@ -71,21 +61,13 @@ function bos_content_type_how_to_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_keep_in_mind'
+  // Exported field_base: 'field_keep_in_mind'.
   $field_bases['field_keep_in_mind'] = array(
     'active' => 1,
     'cardinality' => 1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_keep_in_mind',
-    'foreign keys' => array(
-      'format' => array(
-        'columns' => array(
-          'format' => 'format',
-        ),
-        'table' => 'filter_format',
-      ),
-    ),
     'indexes' => array(
       'format' => array(
         0 => 'format',
@@ -98,21 +80,13 @@ function bos_content_type_how_to_field_default_field_bases() {
     'type' => 'text_long',
   );
 
-  // Exported field_base: 'field_step_details'
+  // Exported field_base: 'field_step_details'.
   $field_bases['field_step_details'] = array(
     'active' => 1,
     'cardinality' => 1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_step_details',
-    'foreign keys' => array(
-      'format' => array(
-        'columns' => array(
-          'format' => 'format',
-        ),
-        'table' => 'filter_format',
-      ),
-    ),
     'indexes' => array(
       'format' => array(
         0 => 'format',

--- a/docroot/sites/all/modules/features/bos_content_type_how_to/bos_content_type_how_to.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/bos_content_type_how_to/bos_content_type_how_to.features.field_instance.inc
@@ -10,7 +10,7 @@
 function bos_content_type_how_to_field_default_field_instances() {
   $field_instances = array();
 
-  // Exported field_instance: 'node-how_to-body'
+  // Exported field_instance: 'node-how_to-body'.
   $field_instances['node-how_to-body'] = array(
     'bundle' => 'how_to',
     'default_value' => NULL,
@@ -128,7 +128,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_contact'
+  // Exported field_instance: 'node-how_to-field_contact'.
   $field_instances['node-how_to-field_contact'] = array(
     'bundle' => 'how_to',
     'default_value' => NULL,
@@ -245,7 +245,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_how_to_tabs'
+  // Exported field_instance: 'node-how_to-field_how_to_tabs'.
   $field_instances['node-how_to-field_how_to_tabs'] = array(
     'bundle' => 'how_to',
     'default_value' => NULL,
@@ -403,7 +403,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_intro_image'
+  // Exported field_instance: 'node-how_to-field_intro_image'.
   $field_instances['node-how_to-field_intro_image'] = array(
     'bundle' => 'how_to',
     'deleted' => 0,
@@ -532,7 +532,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_links'
+  // Exported field_instance: 'node-how_to-field_links'.
   $field_instances['node-how_to-field_links'] = array(
     'bundle' => 'how_to',
     'default_value' => NULL,
@@ -680,7 +680,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_need_to_know'
+  // Exported field_instance: 'node-how_to-field_need_to_know'.
   $field_instances['node-how_to-field_need_to_know'] = array(
     'bundle' => 'how_to',
     'default_value' => NULL,
@@ -788,7 +788,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_payment_info'
+  // Exported field_instance: 'node-how_to-field_payment_info'.
   $field_instances['node-how_to-field_payment_info'] = array(
     'bundle' => 'how_to',
     'default_value' => NULL,
@@ -896,7 +896,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_published_date'
+  // Exported field_instance: 'node-how_to-field_published_date'.
   $field_instances['node-how_to-field_published_date'] = array(
     'bundle' => 'how_to',
     'deleted' => 0,
@@ -1020,7 +1020,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_type_of_content'
+  // Exported field_instance: 'node-how_to-field_type_of_content'.
   $field_instances['node-how_to-field_type_of_content'] = array(
     'bundle' => 'how_to',
     'default_value' => NULL,
@@ -1056,7 +1056,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-how_to-field_updated_date'
+  // Exported field_instance: 'node-how_to-field_updated_date'.
   $field_instances['node-how_to-field_updated_date'] = array(
     'bundle' => 'how_to',
     'deleted' => 0,
@@ -1180,7 +1180,8 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_contact_step-field_address'
+  // Exported field_instance:
+  // 'paragraphs_item-how_to_contact_step-field_address'.
   $field_instances['paragraphs_item-how_to_contact_step-field_address'] = array(
     'bundle' => 'how_to_contact_step',
     'default_value' => NULL,
@@ -1244,7 +1245,8 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_contact_step-field_operation_hours'
+  // Exported field_instance:
+  // 'paragraphs_item-how_to_contact_step-field_operation_hours'.
   $field_instances['paragraphs_item-how_to_contact_step-field_operation_hours'] = array(
     'bundle' => 'how_to_contact_step',
     'default_value' => NULL,
@@ -1342,7 +1344,8 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_contact_step-field_step_details'
+  // Exported field_instance:
+  // 'paragraphs_item-how_to_contact_step-field_step_details'.
   $field_instances['paragraphs_item-how_to_contact_step-field_step_details'] = array(
     'bundle' => 'how_to_contact_step',
     'default_value' => NULL,
@@ -1390,7 +1393,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_contact_step-field_title'
+  // Exported field_instance: 'paragraphs_item-how_to_contact_step-field_title'.
   $field_instances['paragraphs_item-how_to_contact_step-field_title'] = array(
     'bundle' => 'how_to_contact_step',
     'default_value' => NULL,
@@ -1438,7 +1441,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_tab-field_how_to_steps'
+  // Exported field_instance: 'paragraphs_item-how_to_tab-field_how_to_steps'.
   $field_instances['paragraphs_item-how_to_tab-field_how_to_steps'] = array(
     'bundle' => 'how_to_tab',
     'default_value' => NULL,
@@ -1536,7 +1539,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_tab-field_how_to_title'
+  // Exported field_instance: 'paragraphs_item-how_to_tab-field_how_to_title'.
   $field_instances['paragraphs_item-how_to_tab-field_how_to_title'] = array(
     'bundle' => 'how_to_tab',
     'default_value' => NULL,
@@ -1584,7 +1587,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_tab-field_keep_in_mind'
+  // Exported field_instance: 'paragraphs_item-how_to_tab-field_keep_in_mind'.
   $field_instances['paragraphs_item-how_to_tab-field_keep_in_mind'] = array(
     'bundle' => 'how_to_tab',
     'default_value' => NULL,
@@ -1632,7 +1635,8 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_text_step-field_step_details'
+  // Exported field_instance:
+  // 'paragraphs_item-how_to_text_step-field_step_details'.
   $field_instances['paragraphs_item-how_to_text_step-field_step_details'] = array(
     'bundle' => 'how_to_text_step',
     'default_value' => NULL,
@@ -1680,7 +1684,7 @@ function bos_content_type_how_to_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-how_to_text_step-field_title'
+  // Exported field_instance: 'paragraphs_item-how_to_text_step-field_title'.
   $field_instances['paragraphs_item-how_to_text_step-field_title'] = array(
     'bundle' => 'how_to_text_step',
     'default_value' => NULL,

--- a/docroot/sites/all/modules/features/bos_content_type_how_to/bos_content_type_how_to.info
+++ b/docroot/sites/all/modules/features/bos_content_type_how_to/bos_content_type_how_to.info
@@ -74,5 +74,4 @@ features[variable][] = pathauto_node_how_to_pattern
 features[variable][] = xmlsitemap_settings_node_how_to
 features_exclude[field_instance][node-how_to-field_components] = node-how_to-field_components
 features_exclude[field_instance][node-how_to-field_sidebar_components] = node-how_to-field_sidebar_components
-mtime = 1495652915
 packages = Boston

--- a/docroot/sites/all/modules/features/bos_view_calendar_listing/bos_view_calendar_listing.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_calendar_listing/bos_view_calendar_listing.views_default.inc
@@ -496,7 +496,7 @@ function bos_view_calendar_listing_views_default_views() {
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
   $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
 
-<div class="g--6">
+<div class="g--6 fl--l">
 <form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf">
     <input name="utf8" type="hidden" value="✓">
     <div class="sf-i">

--- a/docroot/sites/all/modules/features/bos_view_calendar_listing/bos_view_calendar_listing.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_calendar_listing/bos_view_calendar_listing.views_default.inc
@@ -293,8 +293,6 @@ function bos_view_calendar_listing_views_default_views() {
     'any_label' => NULL,
     'filter_rewrite_values' => NULL,
   );
-  $handler->display->display_options['exposed_form']['options']['input_required'] = 0;
-  $handler->display->display_options['exposed_form']['options']['text_input_required_format'] = 'filtered_html';
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '30';
   $handler->display->display_options['pager']['options']['offset'] = '0';
@@ -344,15 +342,7 @@ function bos_view_calendar_listing_views_default_views() {
   $handler->display->display_options['fields']['rendered_entity']['display'] = 'view';
   $handler->display->display_options['fields']['rendered_entity']['view_mode'] = 'calendar_listing';
   $handler->display->display_options['fields']['rendered_entity']['bypass_access'] = 0;
-  /* Field: Field: Live Stream */
-  $handler->display->display_options['fields']['field_live_stream']['id'] = 'field_live_stream';
-  $handler->display->display_options['fields']['field_live_stream']['table'] = 'field_data_field_live_stream';
-  $handler->display->display_options['fields']['field_live_stream']['field'] = 'field_live_stream';
-  $handler->display->display_options['fields']['field_live_stream']['label'] = '';
-  $handler->display->display_options['fields']['field_live_stream']['exclude'] = TRUE;
-  $handler->display->display_options['fields']['field_live_stream']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_live_stream']['element_default_classes'] = FALSE;
-  /* Sort criterion: Field: Event Dates -  start date (field_event_dates) */
+  /* Sort criterion: Content: Event Dates -  start date (field_event_dates) */
   $handler->display->display_options['sorts']['field_event_dates_value']['id'] = 'field_event_dates_value';
   $handler->display->display_options['sorts']['field_event_dates_value']['table'] = 'field_data_field_event_dates';
   $handler->display->display_options['sorts']['field_event_dates_value']['field'] = 'field_event_dates_value';
@@ -371,7 +361,7 @@ function bos_view_calendar_listing_views_default_views() {
     'event' => 'event',
   );
   $handler->display->display_options['filters']['type']['group'] = 1;
-  /* Filter criterion: Field: Event Dates -  start date (field_event_dates) */
+  /* Filter criterion: Content: Event Dates -  start date (field_event_dates) */
   $handler->display->display_options['filters']['field_event_dates_value']['id'] = 'field_event_dates_value';
   $handler->display->display_options['filters']['field_event_dates_value']['table'] = 'field_data_field_event_dates';
   $handler->display->display_options['filters']['field_event_dates_value']['field'] = 'field_event_dates_value';
@@ -396,7 +386,7 @@ function bos_view_calendar_listing_views_default_views() {
   $handler->display->display_options['filters']['field_event_dates_value']['form_type'] = 'date_popup';
   $handler->display->display_options['filters']['field_event_dates_value']['default_date'] = 'now';
   $handler->display->display_options['filters']['field_event_dates_value']['year_range'] = '-0:+10';
-  /* Filter criterion: Field: Event Dates - end date (field_event_dates:value2) */
+  /* Filter criterion: Content: Event Dates - end date (field_event_dates:value2) */
   $handler->display->display_options['filters']['field_event_dates_value2']['id'] = 'field_event_dates_value2';
   $handler->display->display_options['filters']['field_event_dates_value2']['table'] = 'field_data_field_event_dates';
   $handler->display->display_options['filters']['field_event_dates_value2']['field'] = 'field_event_dates_value2';
@@ -498,6 +488,24 @@ function bos_view_calendar_listing_views_default_views() {
 
   /* Display: Listing */
   $handler = $view->new_display('page', 'Listing', 'listing');
+  $handler->display->display_options['defaults']['empty'] = FALSE;
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
+
+<div class="g--6">
+<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf">
+    <input name="utf8" type="hidden" value="✓">
+    <div class="sf-i">
+        <input type="text" name="query" id="q" placeholder="Search…" class="sf-i-f" autocomplete="off">
+        <button class="sf-i-b">Search</button>
+    </div>
+</form>
+</div>';
+  $handler->display->display_options['empty']['area']['format'] = 'full_html';
   $handler->display->display_options['path'] = 'view-page/calendar';
 
   /* Display: Feed */

--- a/docroot/sites/all/modules/features/bos_view_news_landing/bos_view_news_landing.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_news_landing/bos_view_news_landing.views_default.inc
@@ -209,10 +209,11 @@ function bos_view_news_landing_views_default_views() {
   $handler->display->display_options['empty']['area']['table'] = 'views';
   $handler->display->display_options['empty']['area']['field'] = 'area';
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
-
-<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf">
+  $handler->display->display_options['empty']['area']['content'] = '<h2>No Posts Found</h2>
+<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
+<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf sf--md">
     <input name="utf8" type="hidden" value="✓">
+    <input name="facet[]" type="hidden" value="post">
     <div class="sf-i">
         <input type="text" name="query" id="q" placeholder="Search…" class="sf-i-f" autocomplete="off">
         <button class="sf-i-b">Search</button>

--- a/docroot/sites/all/modules/features/bos_view_news_landing/bos_view_news_landing.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_news_landing/bos_view_news_landing.views_default.inc
@@ -194,8 +194,6 @@ function bos_view_news_landing_views_default_views() {
     'any_label' => NULL,
     'filter_rewrite_values' => NULL,
   );
-  $handler->display->display_options['exposed_form']['options']['input_required'] = 0;
-  $handler->display->display_options['exposed_form']['options']['text_input_required_format'] = 'filtered_html';
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '30';
   $handler->display->display_options['pager']['options']['offset'] = '0';
@@ -206,6 +204,21 @@ function bos_view_news_landing_views_default_views() {
   $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['row_plugin'] = 'node';
   $handler->display->display_options['row_options']['view_mode'] = 'listing';
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
+
+<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf">
+    <input name="utf8" type="hidden" value="✓">
+    <div class="sf-i">
+        <input type="text" name="query" id="q" placeholder="Search…" class="sf-i-f" autocomplete="off">
+        <button class="sf-i-b">Search</button>
+    </div>
+</form>';
+  $handler->display->display_options['empty']['area']['format'] = 'full_html';
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';

--- a/docroot/sites/all/modules/features/bos_view_public_notice/bos_view_public_notice.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_public_notice/bos_view_public_notice.views_default.inc
@@ -152,6 +152,22 @@ function bos_view_public_notice_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'node';
   $handler->display->display_options['row_options']['view_mode'] = 'listing';
   $handler->display->display_options['row_options']['links'] = FALSE;
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = '<h2>No Public Notices Found</h2>
+<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
+<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf sf--md">
+    <input name="utf8" type="hidden" value="✓">
+    <input name="facet[]" type="hidden" value="public_notice">
+    <div class="sf-i">
+        <input type="text" name="query" id="q" placeholder="Search…" class="sf-i-f" autocomplete="off">
+        <button class="sf-i-b">Search</button>
+    </div>
+</form>';
+  $handler->display->display_options['empty']['area']['format'] = 'full_html';
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
@@ -238,10 +254,11 @@ function bos_view_public_notice_views_default_views() {
   $handler->display->display_options['empty']['area']['table'] = 'views';
   $handler->display->display_options['empty']['area']['field'] = 'area';
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
-
-<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf">
+  $handler->display->display_options['empty']['area']['content'] = '<h2>No Public Notices Found</h2>
+<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
+<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf sf--md">
     <input name="utf8" type="hidden" value="✓">
+    <input name="facet[]" type="hidden" value="public_notice">
     <div class="sf-i">
         <input type="text" name="query" id="q" placeholder="Search…" class="sf-i-f" autocomplete="off">
         <button class="sf-i-b">Search</button>

--- a/docroot/sites/all/modules/features/bos_view_public_notice/bos_view_public_notice.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_public_notice/bos_view_public_notice.views_default.inc
@@ -146,8 +146,6 @@ function bos_view_public_notice_views_default_views() {
     'any_label' => NULL,
     'filter_rewrite_values' => NULL,
   );
-  $handler->display->display_options['exposed_form']['options']['input_required'] = 0;
-  $handler->display->display_options['exposed_form']['options']['text_input_required_format'] = 'filtered_html';
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '10';
   $handler->display->display_options['style_plugin'] = 'default';
@@ -234,6 +232,22 @@ function bos_view_public_notice_views_default_views() {
 
   /* Display: Landing */
   $handler = $view->new_display('page', 'Landing', 'landing');
+  $handler->display->display_options['defaults']['empty'] = FALSE;
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
+
+<form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf">
+    <input name="utf8" type="hidden" value="✓">
+    <div class="sf-i">
+        <input type="text" name="query" id="q" placeholder="Search…" class="sf-i-f" autocomplete="off">
+        <button class="sf-i-b">Search</button>
+    </div>
+</form>';
+  $handler->display->display_options['empty']['area']['format'] = 'full_html';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */

--- a/docroot/sites/all/modules/features/bos_view_topics_landing_page/bos_view_topics_landing_page.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_topics_landing_page/bos_view_topics_landing_page.views_default.inc
@@ -98,8 +98,6 @@ function bos_view_topics_landing_page_views_default_views() {
     'any_label' => NULL,
     'filter_rewrite_values' => NULL,
   );
-  $handler->display->display_options['exposed_form']['options']['input_required'] = 0;
-  $handler->display->display_options['exposed_form']['options']['text_input_required_format'] = 'filtered_html';
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '9';
   $handler->display->display_options['pager']['options']['offset'] = '0';
@@ -108,6 +106,23 @@ function bos_view_topics_landing_page_views_default_views() {
   $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['row_plugin'] = 'entity';
   $handler->display->display_options['row_options']['view_mode'] = 'listing_long';
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>
+
+<div class="g--6 fl--l"">
+    <form accept-charset="UTF-8" action="//search.boston.gov" method="get" class="sf">
+        <input name="utf8" type="hidden" value="✓">
+        <div class="sf-i">
+            <input type="text" name="query" id="q" placeholder="Search…" class="sf-i-f" autocomplete="off">
+            <button class="sf-i-b">Search</button>
+        </div>
+    </form>
+</div>';
+  $handler->display->display_options['empty']['area']['format'] = 'full_html';
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';

--- a/docroot/sites/all/modules/features/bos_view_transactions/bos_view_transactions.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_transactions/bos_view_transactions.views_default.inc
@@ -65,7 +65,7 @@ function bos_view_transactions_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'transaction' => 'transaction',
   );
-  /* Filter criterion: Content: Sticky (field_sticky) */
+  /* Filter criterion: Field: Async? (field_sticky) */
   $handler->display->display_options['filters']['field_sticky_value']['id'] = 'field_sticky_value';
   $handler->display->display_options['filters']['field_sticky_value']['table'] = 'field_data_field_sticky';
   $handler->display->display_options['filters']['field_sticky_value']['field'] = 'field_sticky_value';
@@ -82,6 +82,14 @@ function bos_view_transactions_views_default_views() {
   $handler->display->display_options['header']['area']['field'] = 'area';
   $handler->display->display_options['header']['area']['content'] = '[boston:main-transactions-header]';
   $handler->display->display_options['header']['area']['format'] = 'filtered_html';
+  $handler->display->display_options['defaults']['empty'] = FALSE;
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = '<div class="intro-text supporting-text m-t500">Thomas Paine noted "These are the times that try men\'s souls." Well this is a time to try another search.</div>';
+  $handler->display->display_options['empty']['area']['format'] = 'full_html';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */
@@ -98,7 +106,7 @@ function bos_view_transactions_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'transaction' => 'transaction',
   );
-  /* Filter criterion: Content: Sticky (field_sticky) */
+  /* Filter criterion: Field: Async? (field_sticky) */
   $handler->display->display_options['filters']['field_sticky_value']['id'] = 'field_sticky_value';
   $handler->display->display_options['filters']['field_sticky_value']['table'] = 'field_data_field_sticky';
   $handler->display->display_options['filters']['field_sticky_value']['field'] = 'field_sticky_value';
@@ -152,7 +160,6 @@ function bos_view_transactions_views_default_views() {
   $handler->display->display_options['arguments']['null']['summary']['format'] = 'default_summary';
   $handler->display->display_options['arguments']['null']['summary_options']['items_per_page'] = '25';
   $handler->display->display_options['arguments']['null']['specify_validation'] = TRUE;
-  $handler->display->display_options['arguments']['null']['validate']['type'] = 'first_page';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */
@@ -169,7 +176,7 @@ function bos_view_transactions_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'transaction' => 'transaction',
   );
-  /* Filter criterion: Content: Sticky (field_sticky) */
+  /* Filter criterion: Field: Async? (field_sticky) */
   $handler->display->display_options['filters']['field_sticky_value']['id'] = 'field_sticky_value';
   $handler->display->display_options['filters']['field_sticky_value']['table'] = 'field_data_field_sticky';
   $handler->display->display_options['filters']['field_sticky_value']['field'] = 'field_sticky_value';

--- a/docroot/sites/all/themes/custom/boston/src/sass/base/forms/_forms_search_bos.scss
+++ b/docroot/sites/all/themes/custom/boston/src/sass/base/forms/_forms_search_bos.scss
@@ -46,6 +46,7 @@
   .views-exposed-widget.views-submit-button {
     float: none;
     text-align: right;
+    margin-right: 5px;
     margin-top: -65px;
     @include respond-to(xl) {
       margin-top: -50px;

--- a/docroot/sites/all/themes/custom/boston/src/sass/components/drawer/_drawer.scss
+++ b/docroot/sites/all/themes/custom/boston/src/sass/components/drawer/_drawer.scss
@@ -59,12 +59,3 @@
     padding: 0;
   }
 }
-/*
-.b {
-  .view-filters .drawer-trigger:first-child,
-  .views-exposed-widget.views-submit-button input[type="submit"],
-  .views-exposed-widget.views-reset-button input[type="submit"] {
-    margin-top: 0;
-  }
-}
-*/

--- a/docroot/sites/all/themes/custom/boston/src/sass/components/views/views-exposed-filter/_views-exposed-filter.scss
+++ b/docroot/sites/all/themes/custom/boston/src/sass/components/views/views-exposed-filter/_views-exposed-filter.scss
@@ -200,6 +200,7 @@
   input[type="submit"] {
     margin-top: 20px;
     height: 58px;
+    margin-right: 5px;
   }
 }
 .views-exposed-widget.views-reset-button {

--- a/docroot/sites/all/themes/custom/boston/templates/views/views-exposed-form--calendar-listing.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/views/views-exposed-form--calendar-listing.tpl.php
@@ -30,36 +30,39 @@
   print $q;
   ?>
 <?php endif; ?>
-<div class="drawer-trigger mobile-only ">
-  <div class="drawer-trigger-chevron"></div>
-  Filter
-</div>
-<div class="views-exposed-form drawer mobile-only">
-  <div class="views-exposed-widgets clearfix">
+<div class="co">
+  <input id="collapsible" type="checkbox" class="co-f d-n" aria-hidden=true>
+  <label for="collapsible" class="co-t">Filter</label>
+  <div class="co-b p-t200 p-a000--s">
+    <?php $counter = 0; ?>
     <?php foreach($widget_groups as $group_id => $widget_group): ?>
-      <div class="drawer-trigger">
-          <div class="drawer-trigger-chevron"></div>
-          Filter by <?php print $group_id; ?>
-      </div>
-      <div class="drawer">
-        <?php foreach ($widget_group as $widget_id => $widget): ?>
-          <div id="<?php print $widget->id; ?>-wrapper" class="views-exposed-widget views-widget-<?php print $widget_id; ?>">
-            <?php if (!empty($widget->label)): ?>
-              <label for="<?php print $widget->id; ?>">
-                <?php print $widget->label; ?>
-              </label>
-            <?php endif; ?>
-            <?php if (!empty($widget->operator)): ?>
-              <div class="views-operator">
-                <?php print $widget->operator; ?>
+      <div class="dr dr--sm">
+        <input type="checkbox" id="dr-tr-<?php print $counter ?>" class="dr-tr a11y--h">
+        <label for="dr-tr-<?php print $counter ?>" class="dr-h">
+          <div class="dr-ic"><svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 8.5 18 25"><path class="dr-i" d="M16 21L.5 33.2c-.6.5-1.5.4-2.2-.2-.5-.6-.4-1.6.2-2l12.6-10-12.6-10c-.6-.5-.7-1.5-.2-2s1.5-.7 2.2-.2L16 21z"/></svg></div>
+          <div class="dr-t">Filter by <?php print $group_id; ?></div>
+        </label>
+        <div class="dr-c">
+          <?php foreach ($widget_group as $widget_id => $widget): ?>
+            <div id="<?php print $widget->id; ?>-wrapper" class="views-exposed-widget views-widget-<?php print $widget_id; ?>">
+              <?php if (!empty($widget->label)): ?>
+                <label for="<?php print $widget->id; ?>">
+                  <?php print $widget->label; ?>
+                </label>
+              <?php endif; ?>
+              <?php if (!empty($widget->operator)): ?>
+                <div class="views-operator">
+                  <?php print $widget->operator; ?>
+                </div>
+              <?php endif; ?>
+              <div class="views-widget">
+                <?php print $widget->widget; ?>
               </div>
-            <?php endif; ?>
-            <div class="views-widget">
-              <?php print $widget->widget; ?>
             </div>
-          </div>
-        <?php endforeach; ?>
+          <?php endforeach; ?>
+        </div>
       </div>
+      <?php $counter++; ?>
     <?php endforeach; ?>
     <?php if (!empty($sort_by)): ?>
       <div class="views-exposed-widget views-widget-sort-by">

--- a/docroot/sites/all/themes/custom/boston/templates/views/views-view--bos-news-landing.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/views/views-view--bos-news-landing.tpl.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @file
+ * Main view template.
+ *
+ * Variables available:
+ * - $classes_array: An array of classes determined in
+ *   template_preprocess_views_view(). Default classes are:
+ *     .view
+ *     .view-[css_name]
+ *     .view-id-[view_name]
+ *     .view-display-id-[display_name]
+ *     .view-dom-id-[dom_id]
+ * - $classes: A string version of $classes_array for use in the class attribute
+ * - $css_name: A css-safe version of the view name.
+ * - $css_class: The user-specified classes names, if any
+ * - $header: The view header
+ * - $footer: The view footer
+ * - $rows: The results of the view query, if any
+ * - $empty: The empty text to display if the view is empty
+ * - $pager: The pager next/prev links to display, if any
+ * - $exposed: Exposed widget form/info to display
+ * - $feed_icon: Feed icon to display, if any
+ * - $more: A link to view more, if any
+ *
+ * @ingroup views_templates
+ */
+?>
+<div class="<?php print $classes; ?>">
+  <?php print render($title_prefix); ?>
+  <?php if ($title): ?>
+    <?php print $title; ?>
+  <?php endif; ?>
+  <?php print render($title_suffix); ?>
+  <?php if ($header): ?>
+    <div class="view-header">
+      <?php print $header; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($exposed): ?>
+    <div class="view-filters">
+      <?php print $exposed; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($attachment_before): ?>
+    <div class="attachment attachment-before">
+      <?php print $attachment_before; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($rows): ?>
+    <div class="view-content">
+      <?php print $rows; ?>
+    </div>
+  <?php elseif ($empty): ?>
+    <div class="container">
+      <div class="view-empty">
+        <?php print $empty; ?>
+      </div>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($pager): ?>
+    <?php print $pager; ?>
+  <?php endif; ?>
+
+  <?php if ($attachment_after): ?>
+    <div class="attachment attachment-after">
+      <?php print $attachment_after; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($more): ?>
+    <?php print $more; ?>
+  <?php endif; ?>
+
+  <?php if ($footer): ?>
+    <div class="view-footer">
+      <?php print $footer; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($feed_icon): ?>
+    <div class="feed-icon">
+      <?php print $feed_icon; ?>
+    </div>
+  <?php endif; ?>
+
+</div><?php /* class view */ ?>

--- a/docroot/sites/all/themes/custom/boston/templates/views/views-view--calendar--listing.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/views/views-view--calendar--listing.tpl.php
@@ -27,7 +27,7 @@
  * @ingroup views_templates
  */
 ?>
-<div class="<?php print $classes; ?> clearfix">
+<div>
   <?php print render($title_prefix); ?>
   <?php if ($title): ?>
     <?php print $title; ?>
@@ -38,40 +38,36 @@
       <?php print $header; ?>
     </div>
   <?php endif; ?>
-  <?php if ($exposed): ?>
-    <div class="view-filters mobile-100 desktop-33-left sidebar">
-      <?php print $exposed; ?>
-    </div>
-  <?php endif; ?>
-  <?php if ($attachment_before): ?>
-    <div class="attachment attachment-before">
-      <?php print $attachment_before; ?>
-    </div>
-  <?php endif; ?>
 
-  <?php if ($rows): ?>
-    <div class="view-content mobile-100 desktop-66-right">
-      <?php print $rows; ?>
+  <div class="g">
+    <div class="g--4 m-b500">
+      <?php if ($exposed): ?>
+        <?php print $exposed; ?>
+      <?php endif; ?>
     </div>
-  <?php elseif ($empty): ?>
-    <div class="view-empty">
-      <?php print $empty; ?>
+
+    <div class="g--8">
+      <div class="p-b700">
+        <?php if ($attachment_before): ?>
+          <?php print $attachment_before; ?>
+        <?php endif; ?>
+        <?php if ($rows): ?>
+          <?php print $rows; ?>
+        <?php elseif ($empty): ?>
+          <?php print $empty; ?>
+        <?php endif; ?>
+        <?php if ($pager): ?>
+          <?php print $pager; ?>
+        <?php endif; ?>
+        <?php if ($attachment_after): ?>
+          <?php print $attachment_after; ?>
+        <?php endif; ?>
+        <?php if ($more): ?>
+          <?php print $more; ?>
+        <?php endif; ?>
+      </div>
     </div>
-  <?php endif; ?>
-
-  <?php if ($pager): ?>
-    <?php print $pager; ?>
-  <?php endif; ?>
-
-  <?php if ($attachment_after): ?>
-    <div class="attachment attachment-after">
-      <?php print $attachment_after; ?>
-    </div>
-  <?php endif; ?>
-
-  <?php if ($more): ?>
-    <?php print $more; ?>
-  <?php endif; ?>
+  </div>
 
   <?php if ($footer): ?>
     <div class="view-footer">

--- a/make.yml
+++ b/make.yml
@@ -276,6 +276,8 @@ projects:
     version: 1.x-dev
   viewfield:
     version: 2.0
+    patch:
+      - https://www.drupal.org/files/issues/viewfield-empty-views-477244-56.patch
   votingapi:
     version: 2.12
   workbench:


### PR DESCRIPTION
Patches Viewfield contrib module

Features updates to the following Views:
- /news
- /events
- /guides
- /pay-and-apply
- /public-notices

Updates template `sites/all/themes/custom/boston/templates/views/views-view--bos-news-landing.tpl.php` to make no results appear within a container instead of going edge-to-edge.