### PR TITLE
Issue 843 - Show Most Recent news to anonymous users

### DIFF
--- a/docroot/sites/all/modules/features/bos_view_news_announcements/bos_view_news_announcements.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_news_announcements/bos_view_news_announcements.views_default.inc
@@ -215,6 +215,7 @@ function bos_view_news_announcements_views_default_views() {
   $handler = $view->new_display('block', 'News', 'news_events');
   $handler->display->display_options['defaults']['query'] = FALSE;
   $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
   $handler->display->display_options['query']['options']['distinct'] = TRUE;
   $handler->display->display_options['defaults']['empty'] = FALSE;
   /* No results behavior: Global: Text area */

--- a/docroot/sites/all/modules/features/bos_view_news_announcements/bos_view_news_announcements.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_news_announcements/bos_view_news_announcements.views_default.inc
@@ -27,6 +27,7 @@ function bos_view_news_announcements_views_default_views() {
   $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'some';
   $handler->display->display_options['pager']['options']['items_per_page'] = '4';
@@ -147,6 +148,14 @@ function bos_view_news_announcements_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'entity';
   $handler->display->display_options['row_options']['view_mode'] = 'listing_short';
   $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $handler->display->display_options['defaults']['empty'] = FALSE;
+  /* No results behavior: Global: Text area */
+  $handler->display->display_options['empty']['area']['id'] = 'area';
+  $handler->display->display_options['empty']['area']['table'] = 'views';
+  $handler->display->display_options['empty']['area']['field'] = 'area';
+  $handler->display->display_options['empty']['area']['empty'] = TRUE;
+  $handler->display->display_options['empty']['area']['content'] = 'No upcoming posts are available at this time.';
+  $handler->display->display_options['empty']['area']['format'] = 'filtered_html';
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: Entity Reference: Referencing entity */
   $handler->display->display_options['relationships']['reverse_field_featured_post_paragraphs_item']['id'] = 'reverse_field_featured_post_paragraphs_item';


### PR DESCRIPTION
This PR fixes a bug introduced by PR #836 when adding a filter to the view that uses a relationship.

This PR updates feature `bos_view_news_announcements`

**Explanation:**
Needed to "Disable SQL rewriting" under Advanced > Other in the News & Announcements view (/admin/structure/views/view/news_announcements/edit/most_recent). This is a potential security risk because it disables the node access security check, which could allow users to view content they shouldn't be able to. I believe this is low risk since our post content is typically publicly available and the view is configured properly to my knowledge.
 
Also updated the No Results text to: "No upcoming posts are available at this time."