### PR TITLE
Issue 810 - Enhanced WYSIWYG file upload

### DIFF
--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -663,3 +663,17 @@ function bos_profile_update_7028() {
   );
   module_enable($enabled_modules);
 }
+
+/**
+ * Update for 8/30/17.
+ */
+function bos_profile_update_7029() {
+  $enabled_modules = array(
+    'ckeditor_media',
+  );
+  module_enable($enabled_modules);
+  $disabled_modules = array(
+    'imce',
+  );
+  module_disable($disabled_modules);
+}

--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -672,8 +672,4 @@ function bos_profile_update_7029() {
     'ckeditor_media',
   );
   module_enable($enabled_modules);
-  $disabled_modules = array(
-    'imce',
-  );
-  module_disable($disabled_modules);
 }

--- a/docroot/sites/all/modules/features/bos_settings_linkit_editor/bos_settings_linkit_editor.linkit_profiles.inc
+++ b/docroot/sites/all/modules/features/bos_settings_linkit_editor/bos_settings_linkit_editor.linkit_profiles.inc
@@ -22,9 +22,19 @@ function bos_settings_linkit_editor_default_linkit_profiles() {
       'filtered_html' => 'filtered_html',
       'full_html' => 'full_html',
       'plain_text' => 0,
+      'script_source_url' => 0,
     ),
+    'button_text' => 'Search',
     'search_plugins' => array(
-      'entity:profile2' => array(
+      'entity:salesforce_mapping' => array(
+        'enabled' => 0,
+        'weight' => '-10',
+      ),
+      'entity:salesforce_mapping_object' => array(
+        'enabled' => 0,
+        'weight' => '-10',
+      ),
+      'entity:menu_link' => array(
         'enabled' => 0,
         'weight' => '-10',
       ),
@@ -36,10 +46,6 @@ function bos_settings_linkit_editor_default_linkit_profiles() {
         'enabled' => 1,
         'weight' => '-10',
       ),
-      'entity:taxonomy_term' => array(
-        'enabled' => 0,
-        'weight' => '-10',
-      ),
       'entity:comment' => array(
         'enabled' => 0,
         'weight' => '-10',
@@ -48,21 +54,35 @@ function bos_settings_linkit_editor_default_linkit_profiles() {
         'enabled' => 0,
         'weight' => '-10',
       ),
+      'entity:taxonomy_term' => array(
+        'enabled' => 0,
+        'weight' => '-10',
+      ),
     ),
     'entity:node' => array(
       'result_description' => '',
       'bundles' => array(
-        'application' => 0,
+        'advpoll' => 0,
         'article' => 0,
+        'change' => 0,
         'department_profile' => 0,
+        'emergency_alert' => 0,
         'event' => 0,
         'topic_page' => 0,
         'how_to' => 0,
         'landing_page' => 0,
         'listing_page' => 0,
+        'metrolist_affordable_housing' => 0,
+        'person_profile' => 0,
+        'place_profile' => 0,
         'post' => 0,
+        'program_initiative_profile' => 0,
+        'public_notice' => 0,
         'script_page' => 0,
+        'site_alert' => 0,
+        'status_item' => 0,
         'tabbed_content' => 0,
+        'transaction' => 0,
       ),
       'group_by_bundle' => 1,
       'include_unpublished' => 0,
@@ -70,34 +90,58 @@ function bos_settings_linkit_editor_default_linkit_profiles() {
     'entity:taxonomy_term' => array(
       'result_description' => '',
       'bundles' => array(
+        'contact' => 0,
+        'news_tags' => 0,
         'event_type' => 0,
         'neighborhoods' => 0,
-        'news_tags' => 0,
-        'contact' => 0,
-        'topic_category' => 0,
+        'political_party' => 0,
+        'profile_type' => 0,
+        'program_type' => 0,
+        'place_type' => 0,
+        'features' => 0,
         'icons' => 0,
+        'topic_category' => 0,
         'type_of_content' => 0,
+        '311_request' => 0,
+        'holidays' => 0,
+        'public_notice_type' => 0,
+        'newsletters' => 0,
+        'maps_esri_feed' => 0,
+        'maps_basemap' => 0,
       ),
       'group_by_bundle' => 0,
     ),
     'entity:comment' => array(
       'result_description' => '',
       'bundles' => array(
-        'comment_node_application' => 0,
+        'comment_node_advpoll' => 0,
         'comment_node_article' => 0,
+        'comment_node_change' => 0,
         'comment_node_department_profile' => 0,
+        'comment_node_emergency_alert' => 0,
         'comment_node_event' => 0,
         'comment_node_topic_page' => 0,
         'comment_node_how_to' => 0,
         'comment_node_landing_page' => 0,
         'comment_node_listing_page' => 0,
+        'comment_node_metrolist_affordable_housing' => 0,
+        'comment_node_person_profile' => 0,
+        'comment_node_place_profile' => 0,
         'comment_node_post' => 0,
+        'comment_node_program_initiative_profile' => 0,
+        'comment_node_public_notice' => 0,
         'comment_node_script_page' => 0,
+        'comment_node_site_alert' => 0,
+        'comment_node_status_item' => 0,
         'comment_node_tabbed_content' => 0,
+        'comment_node_transaction' => 0,
       ),
       'group_by_bundle' => 0,
     ),
-    'entity:profile2' => array(
+    'entity:salesforce_mapping' => array(
+      'result_description' => '',
+    ),
+    'entity:salesforce_mapping_object' => array(
       'result_description' => '',
     ),
     'entity:file' => array(
@@ -120,18 +164,24 @@ function bos_settings_linkit_editor_default_linkit_profiles() {
     'entity:user' => array(
       'result_description' => '',
     ),
+    'entity:menu_link' => array(
+      'result_description' => '',
+      'bundles' => array(
+        'menu-accessibility-menu' => 0,
+        'menu-footer-menu' => 0,
+        'main-menu' => 0,
+        'management' => 0,
+        'navigation' => 0,
+        'menu-secondary-menu' => 0,
+        'menu-translation-menu' => 0,
+        'user-menu' => 0,
+      ),
+      'group_by_bundle' => 0,
+    ),
     'insert_plugin' => array(
       'url_method' => '3',
     ),
     'attribute_plugins' => array(
-      'accesskey' => array(
-        'enabled' => 0,
-        'weight' => '-10',
-      ),
-      'target' => array(
-        'enabled' => 0,
-        'weight' => '-10',
-      ),
       'class' => array(
         'enabled' => 0,
         'weight' => '-10',
@@ -140,22 +190,31 @@ function bos_settings_linkit_editor_default_linkit_profiles() {
         'enabled' => 0,
         'weight' => '-10',
       ),
-      'id' => array(
-        'enabled' => 0,
-        'weight' => '-10',
-      ),
       'title' => array(
         'enabled' => 0,
         'weight' => '-10',
       ),
+      'id' => array(
+        'enabled' => 0,
+        'weight' => '-10',
+      ),
+      'target' => array(
+        'enabled' => 0,
+        'weight' => '-10',
+      ),
+      'accesskey' => array(
+        'enabled' => 0,
+        'weight' => '-10',
+      ),
     ),
-    'imce' => 1,
+    'imce' => 0,
     'autocomplete' => array(
       'charLimit' => '3',
       'wait' => '350',
       'remoteTimeout' => '10000',
     ),
   );
+  $linkit_profile->weight = 0;
   $export['bos_settings_linkit_editor'] = $linkit_profile;
 
   return $export;

--- a/docroot/sites/all/modules/features/bos_text_formats/bos_text_formats.features.wysiwyg.inc
+++ b/docroot/sites/all/modules/features/bos_text_formats/bos_text_formats.features.wysiwyg.inc
@@ -15,8 +15,6 @@ function bos_text_formats_wysiwyg_default_profiles() {
     'format' => 'filtered_html',
     'editor' => 'ckeditor',
     'settings' => array(
-      'theme' => '',
-      'language' => 'en',
       'buttons' => array(
         'default' => array(
           'Bold' => 1,
@@ -65,6 +63,9 @@ function bos_text_formats_wysiwyg_default_profiles() {
         'tabletools' => array(
           'TableTools' => 1,
         ),
+        'mediaBrowser' => array(
+          'mediaBrowser' => 1,
+        ),
         'linkit' => array(
           'linkit' => 1,
         ),
@@ -72,6 +73,8 @@ function bos_text_formats_wysiwyg_default_profiles() {
           'media' => 1,
         ),
       ),
+      'theme' => '',
+      'language' => 'en',
       'toolbarLocation' => 'top',
       'resize_enabled' => 1,
       'default_toolbar_grouping' => 1,
@@ -79,17 +82,21 @@ function bos_text_formats_wysiwyg_default_profiles() {
       'acf_mode' => 0,
       'acf_allowed_content' => '',
       'css_setting' => 'self',
+      'css_theme' => 'boston_admin',
       'css_path' => '/sites/all/themes/custom/boston/dist/css/styles.css',
       'stylesSet' => '',
       'block_formats' => 'p,address,pre,h2,h3,h4,h5,h6,div',
-      'advanced__active_tab' => 'edit-basic',
       'forcePasteAsPlainText' => 0,
+      'pasteFromWordNumberedHeadingToList' => 0,
+      'pasteFromWordPromptCleanup' => 0,
+      'pasteFromWordRemoveFontStyles' => 1,
+      'pasteFromWordRemoveStyles' => 1,
     ),
     'preferences' => array(
-      'add_to_summaries' => 1,
       'default' => 1,
-      'show_toggle' => 1,
       'user_choose' => 0,
+      'show_toggle' => 1,
+      'add_to_summaries' => 1,
       'version' => '4.5.8.c1fc9a9',
     ),
     'name' => 'formatfiltered_html',
@@ -101,8 +108,6 @@ function bos_text_formats_wysiwyg_default_profiles() {
     'format' => 'full_html',
     'editor' => 'ckeditor',
     'settings' => array(
-      'theme' => '',
-      'language' => 'en',
       'buttons' => array(
         'default' => array(
           'Bold' => 1,
@@ -158,6 +163,9 @@ function bos_text_formats_wysiwyg_default_profiles() {
         'tabletools' => array(
           'TableTools' => 1,
         ),
+        'mediaBrowser' => array(
+          'mediaBrowser' => 1,
+        ),
         'linkit' => array(
           'linkit' => 1,
         ),
@@ -165,6 +173,8 @@ function bos_text_formats_wysiwyg_default_profiles() {
           'media' => 1,
         ),
       ),
+      'theme' => '',
+      'language' => 'en',
       'toolbarLocation' => 'top',
       'resize_enabled' => 1,
       'default_toolbar_grouping' => 0,
@@ -172,17 +182,21 @@ function bos_text_formats_wysiwyg_default_profiles() {
       'acf_mode' => 0,
       'acf_allowed_content' => '',
       'css_setting' => 'self',
+      'css_theme' => 'boston_admin',
       'css_path' => '/sites/all/themes/custom/boston/dist/css/styles.css',
       'stylesSet' => '',
       'block_formats' => 'p,address,pre,h2,h3,h4,h5,h6,div',
-      'advanced__active_tab' => 'edit-basic',
       'forcePasteAsPlainText' => 0,
+      'pasteFromWordNumberedHeadingToList' => 0,
+      'pasteFromWordPromptCleanup' => 0,
+      'pasteFromWordRemoveFontStyles' => 1,
+      'pasteFromWordRemoveStyles' => 1,
     ),
     'preferences' => array(
-      'add_to_summaries' => 1,
       'default' => 1,
-      'show_toggle' => 1,
       'user_choose' => 0,
+      'show_toggle' => 1,
+      'add_to_summaries' => 1,
       'version' => '4.5.8.c1fc9a9',
     ),
     'name' => 'formatfull_html',

--- a/make.yml
+++ b/make.yml
@@ -75,6 +75,8 @@ projects:
     version: 1.4
   chosen:
     version: 2.1
+  ckeditor_media:
+    version: 2.0-beta2
   content_access:
     version: 1.2-beta2
   context:


### PR DESCRIPTION
This PR...

Downloads contrib module CKeditor Media Browser (https://www.drupal.org/project/ckeditor_media) via `make.yml`

Enables the CKeditor Media Browser via `docroot/profiles/bos_profile/bos_profile.install`

Updates features:
- `bos_text_formats` - Enables CKeditor Media Browser for filtered and full WYSIWYG profiles
- `bos_settings_linkit_editor` - Disables IMCE from LinkIt profile (bos_settings_linkit_editor @ /admin/config/content/linkit)

We'll need these feature updates to run before trying to disable IMCE in the profile:
```
/**                                  
 * Update for 8/30/17.               
 */                                  
function bos_profile_update_7030() { 
  $disabled_modules = array(         
    'imce',                          
  );                                 
  module_disable($disabled_modules); 
}                                    
```
Since hook_update runs before the feature revert, it breaks the LinkIt profile, which previously specifies enabling IMCE.

Once these updates have run we can also remove IMCE from the makefile so it no longer gets downloaded on build.	