### PR TITLE
Issue 830 - Update hero and public notice style to fix "Last Updated" text position

### DIFF
--- a/docroot/sites/all/themes/custom/boston/src/sass/components/hero/_hero.scss
+++ b/docroot/sites/all/themes/custom/boston/src/sass/components/hero/_hero.scss
@@ -72,6 +72,9 @@
     .desktop-33-right {
       margin-top: 45px;
     }
+    h1 ~ .desktop-33-right {
+      margin-top: 0px;
+    }
   }
 }
 

--- a/docroot/sites/all/themes/custom/boston/src/sass/components/hero/_hero.scss
+++ b/docroot/sites/all/themes/custom/boston/src/sass/components/hero/_hero.scss
@@ -69,15 +69,9 @@
 .node-type-public-notice .node-public-notice {
   @include respond-to(xl) {
     position: relative;
-    width: 100%;
-    padding: 45px 50px 0;
-    background-color: color(text-bg);
-  }
-  @include respond-to(xxl) {
-    width: calc(100% + 100px);
-    transform: translate(50px, 0);
-    right: 100px;
-
+    .desktop-33-right {
+      margin-top: 45px;
+    }
   }
 }
 

--- a/docroot/sites/all/themes/custom/boston/src/sass/components/node_type/detail-page.scss
+++ b/docroot/sites/all/themes/custom/boston/src/sass/components/node_type/detail-page.scss
@@ -18,13 +18,6 @@
 
   }
 
-  // Heading 1 .title state with-hero
-
-  .with-hero h1.title,
-  .node-public-notice h1.title {
-    margin-top: 0;
-  }
-
   .sidebar-header {
     @include type-layout(l);
     font-style: italic;


### PR DESCRIPTION
This simplifies the style and removes the need for overrides in a couple of areas. I tested locally and everything seemed ok, but this should be tested thoroughly as it can affect the display of several content types. This PR follows "approach 1" detailed on issue #830 

@matthewcrist it's possible I'm missing the necessity of transform and width calculations I removed, please let me know if I'm breaking something you're aware of.

In the pattern library at stylesheets/components/breadcrumb/_main.styl we should also remove this override at the bottom of the file (starting around line 79):
```
.node-public-notice
   .brc-lu
      margin-top: -92px
```
(pulling the "Last updated" text up beyond its normal position is no longer necessary with these changes)