### PR TITLE
Issue 872 - Slack integration for content publishing / needs review alerts

### DIFF
--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -672,6 +672,7 @@ function bos_profile_update_7029() {
     'rules',
     'entity_token',
     'slack',
+    'bos_slack',
   );
   module_enable($enabled_modules);
 }

--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -669,6 +669,8 @@ function bos_profile_update_7028() {
  */
 function bos_profile_update_7029() {
   $enabled_modules = array(
+    'rules',
+    'entity_token',
     'slack',
   );
   module_enable($enabled_modules);

--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -663,3 +663,13 @@ function bos_profile_update_7028() {
   );
   module_enable($enabled_modules);
 }
+
+/**
+ * Update for 10/12/17
+ */
+function bos_profile_update_7029() {
+  $enabled_modules = array(
+    'slack',
+  );
+  module_enable($enabled_modules);
+}

--- a/docroot/sites/all/modules/features/bos_slack/bos_slack.info
+++ b/docroot/sites/all/modules/features/bos_slack/bos_slack.info
@@ -1,0 +1,12 @@
+name = Boston Slack
+description = Uses Rules to send messages to a Slack channel when content is set to particular states
+core = 7.x
+package = Features
+version = 7.x-1.0
+dependencies[] = entity
+dependencies[] = rules
+dependencies[] = slack
+dependencies[] = workbench_moderation
+features[features_api][] = api:2
+features[rules_config][] = rules_slack_alert_node_needs_review
+features[rules_config][] = rules_slack_alert_node_published

--- a/docroot/sites/all/modules/features/bos_slack/bos_slack.module
+++ b/docroot/sites/all/modules/features/bos_slack/bos_slack.module
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Drupal needs this blank file.
+ */

--- a/docroot/sites/all/modules/features/bos_slack/bos_slack.rules_defaults.inc
+++ b/docroot/sites/all/modules/features/bos_slack/bos_slack.rules_defaults.inc
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @file
+ * bos_slack.rules_defaults.inc
+ */
+
+/**
+ * Implements hook_default_rules_configuration().
+ */
+function bos_slack_default_rules_configuration() {
+  $items = array();
+  $items['rules_slack_alert_node_needs_review'] = entity_import('rules_config', '{ "rules_slack_alert_node_needs_review" : {
+      "LABEL" : "Slack alert: Node needs review",
+      "PLUGIN" : "reaction rule",
+      "OWNER" : "rules",
+      "REQUIRES" : [ "workbench_moderation", "rules", "slack" ],
+      "ON" : { "node_insert" : [], "node_update" : [] },
+      "IF" : [
+        { "contents_current_state" : { "node" : [ "node" ], "moderation_state" : "needs_review" } }
+      ],
+      "DO" : [
+        { "slack_send_message" : { "message" : "A Node of type [node:content-type] has been set to \\u0022Needs Review\\u0022 by [site:current-user].\\r\\nNode ID: [node:nid]\\r\\nTitle: [node:title]\\r\\nAuthor: [node:author]\\r\\nURL: [node:url]\\r\\nCreated: [node:created]\\r\\nLast Updated: [node:changed]" } }
+      ]
+    }
+  }');
+  $items['rules_slack_alert_node_published'] = entity_import('rules_config', '{ "rules_slack_alert_node_published" : {
+      "LABEL" : "Slack alert: Node published",
+      "PLUGIN" : "reaction rule",
+      "OWNER" : "rules",
+      "REQUIRES" : [ "workbench_moderation", "rules", "slack" ],
+      "ON" : { "node_insert" : [], "node_update" : [] },
+      "IF" : [
+        { "contents_current_state" : { "node" : [ "node" ], "moderation_state" : "published" } }
+      ],
+      "DO" : [
+        { "slack_send_message" : { "message" : "A Node of type [node:content-type] has been set to \\u0022Published\\u0022 by [site:current-user].\\r\\nNode ID: [node:nid]\\r\\nTitle: [node:title]\\r\\nAuthor: [node:author]\\r\\nURL: [node:url]\\r\\nCreated: [node:created]\\r\\nLast Updated: [node:changed]" } }
+      ]
+    }
+  }');
+  return $items;
+}

--- a/make.yml
+++ b/make.yml
@@ -222,6 +222,8 @@ projects:
     version: 1.2
   shunt:
     version: 1.3
+  slack:
+    version: 1.6
   stage_file_proxy:
     version: 1.7
   strongarm:


### PR DESCRIPTION
1. - Adds Slack module: http://drupal.org/project/slack
2. - Enables: Rules + Entity Token (already part of codebase)
3. - Creates `bos_slack` feature.

**Note:** After merging, we will need to manually set up the Webhook URL, Default Channel, and Default Username in Drupal's settings: `/admin/config/services/slack/config`