### PR TITLE
Features Update: Remove field_title from video paragraph.

### DIFF
--- a/docroot/sites/all/modules/features/bos_component_video/bos_component_video.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/bos_component_video/bos_component_video.features.field_instance.inc
@@ -307,53 +307,6 @@ function bos_component_video_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'paragraphs_item-video-field_title'.
-  $field_instances['paragraphs_item-video-field_title'] = array(
-    'bundle' => 'video',
-    'default_value' => NULL,
-    'deleted' => 0,
-    'description' => '',
-    'display' => array(
-      'default' => array(
-        'label' => 'hidden',
-        'module' => 'text',
-        'settings' => array(),
-        'type' => 'text_plain',
-        'weight' => 0,
-      ),
-      'paragraphs_editor_preview' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-    ),
-    'entity_type' => 'paragraphs_item',
-    'fences_wrapper' => 'no_wrapper',
-    'field_name' => 'field_title',
-    'label' => 'Title',
-    'required' => 1,
-    'settings' => array(
-      'linkit' => array(
-        'button_text' => 'Search',
-        'enable' => 0,
-        'profile' => '',
-      ),
-      'text_processing' => 0,
-      'user_register_form' => FALSE,
-    ),
-    'widget' => array(
-      'active' => 1,
-      'module' => 'text',
-      'settings' => array(
-        'show_token_tree' => 0,
-        'size' => 60,
-      ),
-      'type' => 'text_textfield',
-      'weight' => 1,
-    ),
-  );
-
   // Translatables
   // Included for use with string extractors like potx.
   t('Department');

--- a/docroot/sites/all/modules/features/bos_component_video/bos_component_video.info
+++ b/docroot/sites/all/modules/features/bos_component_video/bos_component_video.info
@@ -20,5 +20,4 @@ features[field_instance][] = paragraphs_item-video-field_extra_info
 features[field_instance][] = paragraphs_item-video-field_image
 features[field_instance][] = paragraphs_item-video-field_is_channel
 features[field_instance][] = paragraphs_item-video-field_short_title
-features[field_instance][] = paragraphs_item-video-field_title
 features[paragraphs][] = video


### PR DESCRIPTION
Deletes the old `field_title` from the Video component.

This can be run simultaneously with step 2 which disables the modules and updates the display.