### PR TITLE
Issue 635 step3 - Remove old field instance on video component

### DIFF
--- a/docroot/sites/all/modules/features/bos_component_video/bos_component_video.field_group.inc
+++ b/docroot/sites/all/modules/features/bos_component_video/bos_component_video.field_group.inc
@@ -26,7 +26,6 @@ function bos_component_video_field_group_info() {
       0 => 'field_extra_info',
       1 => 'field_image',
       2 => 'field_short_title',
-      3 => 'field_title',
       4 => 'field_contact',
       5 => 'field_is_channel',
       6 => 'field_component_title',

--- a/docroot/sites/all/modules/features/bos_component_video/bos_component_video.install
+++ b/docroot/sites/all/modules/features/bos_component_video/bos_component_video.install
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ *  Remove old title field instance.
+ */
+function bos_component_video_update_7001() {
+  if ($instance = field_info_instance('paragraphs_item', 'field_title', 'video')) {
+    field_delete_instance($instance);
+  }
+  field_purge_batch(500);
+  features_revert_module('bos_component_video');
+}


### PR DESCRIPTION
Adds an `.install` file to the bos_component_video feature that runs `hook_update_N()` in order to remove the field instance from the video paragraph. 

Updating features will not remove fields by default: https://drupal.stackexchange.com/questions/27442/features-workflow-issue-with-deleting-a-field

Without this update, you would see the field removed from the feature on features-revert, but it would still be visible in the paragraph.