### PR TITLE
Manage component fields separate from content type features on hub.

### DIFF
--- a/docroot/profiles/hub_profile/hub_profile.install
+++ b/docroot/profiles/hub_profile/hub_profile.install
@@ -429,3 +429,14 @@ function hub_profile_update_7022() {
   );
   module_enable($enabled_modules);
 }
+
+/**
+ * Update for 11/7/17
+ */
+function hub_profile_update_7023() {
+  $enabled_modules = array(
+    'paragraphs_reference_manager',
+    'bos_field_instances',
+  );
+  module_enable($enabled_modules);
+}

--- a/tests/behat/features/intranet/content_types.feature
+++ b/tests/behat/features/intranet/content_types.feature
@@ -17,6 +17,7 @@ Feature: Content Types
       | Post               |
       | Guide              |
       | Tabbed Content     |
+      | Place Profile      |
 
   Scenario Outline: Verify content types do not exist
     Then content type "<content_type>" does not exist
@@ -24,4 +25,3 @@ Feature: Content Types
     Examples:
       | content_type               |
       | Advanced Poll              |
-      | Place Profile              |


### PR DESCRIPTION
This fixes the missing `field_component` from program/initiative profiles on the Hub.