### PR TITLE
Issue 929 - Prevent admins from deleting user content on account cancel

### DIFF
--- a/docroot/sites/all/modules/custom/bos_core/bos_core.module
+++ b/docroot/sites/all/modules/custom/bos_core/bos_core.module
@@ -459,3 +459,11 @@ function bos_core_flush_caches() {
   // be cleared.
   return array();
 }
+
+/**
+ * Implements hook_form_ID_alter().
+ */
+function bos_core_form_user_cancel_confirm_form_alter(&$form, &$form_state, $form_id) {
+  // Prevent admins from deleting users without reassigning content.
+  $form['user_cancel_method']['user_cancel_delete']['#disabled'] = TRUE;
+}

--- a/docroot/sites/all/modules/custom/bos_core/bos_core.module
+++ b/docroot/sites/all/modules/custom/bos_core/bos_core.module
@@ -189,7 +189,7 @@ function walk_recursive_remove(array $array, callable $callback) {
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_ID_alter().
  */
 function bos_core_form_node_form_alter(&$form, &$form_state) {
   if (isset($form['field_components']) || isset($form['field_tabbed_content'])) {
@@ -461,9 +461,11 @@ function bos_core_flush_caches() {
 }
 
 /**
- * Implements hook_form_ID_alter().
+ * Implements hook_form_alter().
  */
-function bos_core_form_user_cancel_confirm_form_alter(&$form, &$form_state, $form_id) {
-  // Prevent admins from deleting users without reassigning content.
-  $form['user_cancel_method']['user_cancel_delete']['#disabled'] = TRUE;
+function bos_core_form_alter(&$form, &$form_state, $form_id) {
+  if ($form['#id'] == 'views-form-admin-views-user-system-1' || $form['#id'] == 'user-cancel-confirm-form') {
+    // Prevent admins from deleting users without reassigning content.
+    $form['user_cancel_method']['user_cancel_delete']['#disabled'] = TRUE;
+  }
 }


### PR DESCRIPTION
Adds `hook_form_alter` to sites/all/modules/custom/bos_core/bos_core.module for the user delete forms (single and multiple).