### PR TITLE
Updates README to use IP address for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Get started with our [developer guide](https://github.com/CityOfBoston/boston.go
 1. Clone this repo
 1. Run `docker-compose up` in the root directory
 1. Initialize the database: `docker exec bostongov_drupal_1 scripts/init-docker-container.sh` (this will take 10+ minutes)
-1. Visit http://localhost:8888/ to see the blank install. Visit
-   http://localhost:8888/user?local to log in, with admin/admin as username and
+1. Visit http://127.0.0.1:8888/ to see the blank install. Visit
+   http://127.0.0.1:8888/user?local to log in, with admin/admin as username and
    password.
 
 The Hub — our internal Drupal install — can run in the same container and
@@ -38,8 +38,8 @@ against the same MySQL server. To initialize it, run:
 
 `docker exec bostongov_drupal_1 scripts/init-docker-container.sh hub`
 
-It’s available at http://localhost:8889/ and you can log in with admin/admin at
-http://localhost:8889/user?local
+It’s available at http://127.0.0.1:8889/ and you can log in with admin/admin at
+http://127.0.0.1:8889/user?local
 
 Since pulling files through the Docker volume mount is relatively slow, we keep
 vendored packages within the container and only map in our custom directories.


### PR DESCRIPTION
The site is configured to think of itself at the IP address (due to test
setup) so it's best to access it there.