### PR TITLE
Sort criteria for status items view

### DIFF
--- a/docroot/sites/all/modules/features/bos_view_status_displays/bos_view_status_displays.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_status_displays/bos_view_status_displays.views_default.inc
@@ -42,6 +42,12 @@ function bos_view_status_displays_views_default_views() {
   $handler->display->display_options['fields']['item_id']['id'] = 'item_id';
   $handler->display->display_options['fields']['item_id']['table'] = 'paragraphs_item';
   $handler->display->display_options['fields']['item_id']['field'] = 'item_id';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['relationship'] = 'field_messages_node';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
   /* Contextual filter: Field: Date (field_date) */
   $handler->display->display_options['arguments']['field_date_value']['id'] = 'field_date_value';
   $handler->display->display_options['arguments']['field_date_value']['table'] = 'field_data_field_date';

--- a/docroot/sites/all/modules/features/bos_view_status_displays/bos_view_status_displays.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_view_status_displays/bos_view_status_displays.views_default.inc
@@ -42,6 +42,12 @@ function bos_view_status_displays_views_default_views() {
   $handler->display->display_options['fields']['item_id']['id'] = 'item_id';
   $handler->display->display_options['fields']['item_id']['table'] = 'paragraphs_item';
   $handler->display->display_options['fields']['item_id']['field'] = 'item_id';
+  /* Sort criterion: Node: Published at */
+  $handler->display->display_options['sorts']['published_at']['id'] = 'published_at';
+  $handler->display->display_options['sorts']['published_at']['table'] = 'publication_date';
+  $handler->display->display_options['sorts']['published_at']['field'] = 'published_at';
+  $handler->display->display_options['sorts']['published_at']['relationship'] = 'field_messages_node';
+  $handler->display->display_options['sorts']['published_at']['order'] = 'DESC';
   /* Sort criterion: Content: Post date */
   $handler->display->display_options['sorts']['created']['id'] = 'created';
   $handler->display->display_options['sorts']['created']['table'] = 'node';


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov/issues/1029
<br>

#### Changes proposed in this pull request:
* Adds primary sort criteria of Published date to homepage status items
* Adds secondary sort criteria of Authored date to homepage status items

#### Add @mentions of the person or team responsible for reviewing proposed changes
