### PR TITLE
Features update (manual): Add application grid to list component.

### DIFF
--- a/docroot/sites/all/modules/features/bos_component_list/bos_component_list.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/bos_component_list/bos_component_list.features.field_instance.inc
@@ -214,6 +214,7 @@ function bos_component_list_field_default_field_instances() {
         'change_log' => 0,
         'feed_departments' => 0,
         'feed_events' => 0,
+        'hub_list_applications' => 'hub_list_applications',
         'media_default' => 0,
         'metrolist_affordable_housing' => 'metrolist_affordable_housing',
         'news_announcements' => 0,


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov/issues/980

#### Changes proposed in this pull request:
* Enables `hub_list_applications` in `List` component
* **Note:** This feature is shared across boston.gov and the hub. These two sites do not necessarily have the same options available, so updating the feature with info from one db might inadvertently disable some of the options on the other site. Manually adding values to the list avoids this issue. 

#### Add @mentions of the person or team responsible for reviewing proposed changes
Review requested for @matthewcrist 