### PR TITLE
Updated Docker configuration and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-av
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git zip unzip bzip2 libbz2-dev rsync nodejs libgd-dev mysql-client && \
+    apt-get install -y --no-install-recommends git zip unzip bzip2 libbz2-dev rsync nodejs libgd-dev mysql-client openssh-client vim && \
     docker-php-ext-install pdo_mysql gd bz2
 RUN curl --silent --show-error https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-av
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git zip unzip bzip2 libbz2-dev rsync nodejs libgd-dev mysql-client openssh-client vim && \
+    apt-get install -y --no-install-recommends git zip unzip bzip2 libbz2-dev rsync nodejs libgd-dev mysql-client openssh-client && \
     docker-php-ext-install pdo_mysql gd bz2
 RUN curl --silent --show-error https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ docker exec bostongov_drupal_1 ./task.sh -Dbehat.run-server=true -Dproject.build
 
 _Note: as of this writing, the tests do not work for the Hub environment (`./hub-task.sh`)._
 
+##### Running `drush` commands with Acquia cloud site alias
+A drush alias is a shortcut to a remote Drupal site. It is in essence a tunnel through which drush commands can be issued. To use Drush to connect to Acquia Cloud site aliases, you must:
+
+1. [Register SSH public keys for your Acquia user profile](https://docs.acquia.com/acquia-cloud/ssh/enable/add-key)
+2. [Download Drush aliases for all of your sites and extract the archive into $HOME.](https://docs.acquia.com/acquia-cloud/drush/aliases)
+3. Ensure that your Acquia cloud site aliases are available with `drush sa`.  You should see the aliases listed.  If not, check that you exported the archive to your $HOME directory.
+
 ## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [LICENSE](LICENSE.md):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     - "8889:80"
     volumes:
     - .:/host-repo:cached
+    - ~/.acquia:/root/.acquia
+    - ~/.drush:/root/.drush
+    - ~/.ssh:/root/.ssh
     environment:
     - DRUPAL_DATABASE_HOST=mysql
   mysql:


### PR DESCRIPTION
#### Fixes [insert bug/issue number] 
For internal developers, some configuration and documentation was needed to facilitate configuring the Acquia cloud site aliases in the docker container.

#### Changes proposed in this pull request:
* Installed ssh client to ssh to Acquia Cloud
* Installed vim to edit files in container
* Mapped folders to facilitate Acqia cloud site alias configuration
* Updateed README to document Acquia cloud site license configuration process

#### Add @mentions of the person or team responsible for reviewing proposed changes
@jimafisk @finneganh