### PR TITLE
Tweaks to memory settings in the containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,11 @@ services:
     - DRUPAL_DATABASE_HOST=mysql
   mysql:
     image: "mysql:5.6"
-    command: ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
+    command:
+      - "--character-set-server=utf8mb4"
+      - "--collation-server=utf8mb4_unicode_ci"
+      - "--innodb-buffer-pool-size=256M"
+      - "--key-buffer-size=10M" 
     ports:
     - "3306:3306"
     environment:

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,2 +1,2 @@
-memory_limit = 256M
+memory_limit = 512M
 max_execution_time = 60


### PR DESCRIPTION
 - Gives MySQL more memory for caching tables
 - Gives PHP more memory so it doesn’t run out

#### Fixes [insert bug/issue number]
<br>

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
