### PR TITLE
Avoids linking blank Commissions department link

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--commission-info.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--commission-info.tpl.php
@@ -6,7 +6,15 @@ if ($content['field_show_contact_info']['#items'][0]['value'] == '1') {
 ?>
 <div class="article-contact">
   <address>
-    <h5 class="contact-title"><a href="<?php print render($content['department_url']); ?>"><?php print render($content['department_name']); ?></a></h5>
+    <h5 class="contact-title">
+      <?php if ($content['department_url']) { ?>
+        <a href="<?php print render($content['department_url']); ?>">
+          <?php print render($content['department_name']); ?>
+        </a>
+      <?php } else { ?>
+        <?php print render($content['department_name']); ?>
+      <?php } ?>
+    </h5>
     <?php if (isset($content['contact_email'])): ?>
       <div class="list-item">
         <?php 


### PR DESCRIPTION
For the rollout, not all departments in the database may have links. In
the meantime, don’t try to make a link to point to a blank HREF.

Fixes #1071

#### Fixes [insert bug/issue number]
<br>

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
