### PR TITLE
Fixes white/blue text issue with newsletters blue theme.

### DIFF
--- a/docroot/sites/all/themes/custom/boston/template.php
+++ b/docroot/sites/all/themes/custom/boston/template.php
@@ -1852,6 +1852,9 @@ function boston_preprocess_paragraphs_item(&$variables) {
 
   if ($theme) {
     $variables['component_theme'] = $theme['value'];
+    if ($theme['value'] == "b" && $variables['paragraphs_item']->bundle == "newsletter") {
+      $variables['component_theme'] .= " b--wt";
+    }
     $variables['section_header_theme'] = $theme['value'] === 'b' ? 'sh--w' : '';
   }
 }


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
#856 

#### Changes proposed in this pull request:
* adds class to set intro text white when newsletter paragraph has blue background.

#### Add @mentions of the person or team responsible for reviewing proposed changes
@jimafisk 