### PR TITLE
Adds prefix to DRUPAL_BASE_URL for correct base-url personalization.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "container_build_command": "docker build -t $APP_NAME/$INSTANCE_NAME -f dockerfiles/drupal .",
     "environment": [
       "DRUPAL_DATABASE_HOST=mysql",
-      "DRUPAL_BASE_URL=$VIRTUAL_HOST",
+      "DRUPAL_BASE_URL=http://$VIRTUAL_HOST",
       "DRUPAL_SITE=default"
     ],
     "services": {


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
Adhoc Labtest environment change

#### Changes proposed in this pull request:
* adds http:// prefix to DRUPAL_BASE_URL which is needed to ensure $base_url is mapped correctly for the experiment.

#### Add @mentions of the person or team responsible for reviewing proposed changes
@jimafisk @coordt 