### PR TITLE
workbench moderation revert rebased

### DIFF
--- a/docroot/profiles/bos_profile/bos_profile.install
+++ b/docroot/profiles/bos_profile/bos_profile.install
@@ -53,6 +53,7 @@ function bos_profile_install() {
   bos_profile_update_7035();
   bos_profile_update_7036();
   bos_profile_update_7037();
+  bos_profile_update_7038();
 }
 
 /**
@@ -1157,6 +1158,13 @@ function bos_profile_update_7037() {
         'bos_component_lightbox_link',
     );
     module_enable($enabled_modules);
+}
+
+function bos_profile_update_7038(){
+   $disabled_modules = array(
+      'drafty',
+   );
+   module_disable($disabled_modules);
 }
 
 /*******************************************************************

--- a/make.yml
+++ b/make.yml
@@ -283,10 +283,17 @@ projects:
     version: 2.12
   workbench:
     version: 1.2
-  drafty:
-    version: 1.0-rc1
   workbench_moderation:
-    version: 3.0
+    version: 1.4
+    patch:
+      # This allows authenticated users to view drafts
+      - https://www.drupal.org/files/workbench_moderation-view-drafts-permission-fix-1461950-8.patch
+      # Without this patch, Behat tests will fail when using fixtures in
+      # combination with Workbench Moderation.
+      - https://www.drupal.org/files/issues/node-deleted-before-shutdown-function-2645622-1.patch
+      # Fixes the issue with the "Generate automatic URL alias" being unchecked
+      # after workbench moderation content is published.
+      - https://www.drupal.org/files/issues/workbench_moderation-pathauto_alias_issue-2308095-20.patch
   #Dev version of WYSIWYG is required for 4.x CKEditor to work.
   workbench_scheduler:
     version: 2.0


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
* Workbench Moderation does not work as expected
* Timestamps are out of order

#### Changes proposed in this pull request:
* Reverts Workbench Moderation module to 1.4
* Remove Drafty module dependency