### PR TITLE
Truncate cache and revision tables.

### DIFF
--- a/build/custom/phing/tasks/local-setup.xml
+++ b/build/custom/phing/tasks/local-setup.xml
@@ -6,7 +6,7 @@
           depends="setup:drupal:settings">
     <exec dir="${docroot}" command="chown -R root:root /root/.ssh" logoutput="true"/>
     <exec dir="${docroot}" command="${drush.cmd} sql-drop -y" logoutput="true"/>
-    <exec dir="${docroot}" command="${drush.cmd} sql-sync ${project.cloud_alias}.test @self --create-db --structure-tables-key=lightweight -y" logoutput="true"/>
+    <exec dir="${docroot}" command="${drush.cmd} sql-sync ${project.cloud_alias}.test @self --create-db --structure-tables-list='field_revision*,cache*' -y" logoutput="true"/>
     <exec dir="${docroot}" command="${drush.cmd} cc all" logoutput="true"/>
     <exec dir="${docroot}" command="${drush.cmd} cc drush" logoutput="true"/>
   </target>


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov/issues/1065

#### Changes proposed in this pull request:
*  Truncates `field_revision` tables for sql-sync

#### Add @mentions of the person or team responsible for reviewing proposed changes
