### PR TITLE
Adds mkdir for files

### DIFF
--- a/scripts/drupal-entrypoint.sh
+++ b/scripts/drupal-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 
 # Every time we start up we need to make sure that we can write to this
 # directory.
+mkdir -p /boston.gov/docroot/sites/default/files
 chown -R www-data /boston.gov/docroot/sites/default/files
 
 # We need to set the permissions here because on AWS this is a bind mount.

--- a/scripts/init-docker-container.sh
+++ b/scripts/init-docker-container.sh
@@ -29,5 +29,6 @@ then
 else
   ./task.sh -Dproject.build_db_from=initialize build:local
   # Need to re-do this chown now that things are symlinked in.
-  chown -R www-data /boston.gov/docroot/sites/default/files 
+  mkdir -p /boston.gov/docroot/sites/default/files
+  chown -R www-data /boston.gov/docroot/sites/default/files
 fi


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
No /boston.gov/docroot/sites/default/files exists at the time of the chown

#### Changes proposed in this pull request:
* mkdir files directory