### PR TITLE
Adds stash-db to on-demand test instances

### DIFF
--- a/build/custom/phing/build.xml
+++ b/build/custom/phing/build.xml
@@ -38,7 +38,16 @@
               <phingcall target="setup:drupal:install"/>
           </then>
           <else>
-              <phingcall target="local:sync"/>
+              <if>
+                  <equals arg1="${project.build_db_from}" arg2="dump" />
+                  <then>
+                      <exec dir="${docroot}" command="${drush.cmd} sql-create -y" logoutput="true"/>
+                      <exec dir="${docroot}" command="${drush.cmd} sql-cli &lt; /tmp/dump.sql" logoutput="true"/>
+                  </then>
+                  <else>
+                      <phingcall target="local:sync"/>
+                  </else>
+              </if>
               <phingcall target="local:update"/>
           </else>
       </if>

--- a/doit
+++ b/doit
@@ -60,6 +60,9 @@ function doithelp() {
   echo -e "${LightBlue}  cheatsheet${NC}  List of drush commands helpful to City of Boston (COB) dev."
   echo -e "${LightBlue}  stage <variant>${NC}       Build and push a container to the staging cluster"
   echo $'\r'
+  echo -e "${Yellow}Staging Commands:${NC}"
+  echo -e "${LightBlue}  stash-db${NC}    Run on staging webconsole.php to save the variant’s database."
+  echo $'\r'
 }
 
 # Use docker-compose to start the containers.
@@ -195,6 +198,7 @@ function doitstage() {
   # ECS UI to put the service on the latest task definition.
   doitcomment "Updating service ${service}."
   deployment_id=`aws ecs update-service \
+    --format json \
     --cluster "${cluster}" \
     --service "${service}" \
     --desired-count 1 \
@@ -211,6 +215,7 @@ function doitstage() {
   while [ "${task_arn}" == "null" ]; do
     sleep 5
     task_arn=`aws ecs list-tasks \
+      --format json \
       --cluster "${cluster}" \
       --started-by "${deployment_id}" | jq '.["taskArns"][0]' -r -`
   done
@@ -239,6 +244,7 @@ function doitstage() {
     # through the loop. We use 2>&1 to capture stdout and stderr so that we
     # swallow any expected "logs not created yet" error messages.
     events=$(aws logs get-log-events \
+      --format json
       --log-group-name "${cluster}/${service_base}" \
       --log-stream-name "ecs/${drupal_container_name}/${task_id}" \
       --next-token "${next_forward_token}" 2>&1)
@@ -275,6 +281,47 @@ function doitstage() {
   doitcomment "Login:" "https://${service}.digital-staging.boston.gov/user?local"
   doitcomment "Web console:" "https://${service}.digital-staging.boston.gov/webconsole.php"
   doitcomment "CloudWatch logs:" "${logs_url}"
+}
+
+function doitstashdb() {
+  subcommand="${args[0]}"
+
+  if [ -z "${AWS_S3_DATABASE_URL}" ]; then
+    echo '$AWS_S3_DATABASE_URL not set. You must run this command on staging.'
+    exit -1
+  fi
+
+  s3_dump_location="${AWS_S3_DATABASE_URL}/dump.sql.gz"
+
+  if [ "${subcommand}" = "reset" ]; then
+    doitcomment "Deleting database dump from S3."
+    aws s3 rm "${s3_dump_location}"
+    exit
+  fi
+
+  if [ "${subcommand}" = "fetch" ]; then
+    doitcomment "Fetching dump from S3"
+
+    aws s3 cp "${AWS_S3_DATABASE_URL}/dump.sql.gz" /tmp/ || doitcomment "dump.sql.gz not found on S3"
+
+    if [ -f /tmp/dump.sql.gz ]; then
+      doitcomment "Ungzipping"
+      gunzip /tmp/dump.sql.gz
+      # Allows the Apache user to overwrite this
+      chmod a+w /tmp/dump.sql
+    fi
+
+    exit
+  fi
+
+  doitcomment "Dumping database SQL."
+  drush --root=/boston.gov/docroot sql-dump > /tmp/dump.sql
+
+  doitcomment "Gzipping dump."
+  gzip /tmp/dump.sql
+
+  doitcomment "Uploading to S3."
+  aws s3 cp --no-progress /tmp/dump.sql.gz "${s3_dump_location}"
 }
 
 # Quick cheatsheet of common commands.
@@ -379,6 +426,8 @@ if [[ -n "$command" ]]; then
     doitserve
   elif [[ $command == "stage" ]]; then
     doitstage
+  elif [[ $command == "stash-db" ]]; then
+    doitstashdb
   else
     echo "$command is not a valid command. Please use \"./doit help\" to see what is available."
   fi

--- a/scripts/run-staging-container.sh
+++ b/scripts/run-staging-container.sh
@@ -27,9 +27,20 @@ else
   chmod 400 /root/.ssh/id_rsa
 fi
 
+./doit stash-db fetch
+
+if [ -f /tmp/dump.sql ]; then
+  # This read in build.xml and causes us to initialize from /tmp/dump.sql rather
+  # than from a sync from staging.
+  db_from=dump
+else
+  # The default, which pulls from staging.
+  db_from=sync
+fi
+
 # Sets up the database by initializing from the latest copy of the staging DB
 # from Acquia, then runs local unapplied install hooks.
-./task.sh build:local
+./task.sh -Dproject.build_db_from=$db_from build:local
 
 # Necessary so that Apache can write proxied assets to the filesystem.
 chown -R www-data /boston.gov/docroot/sites/default/files 


### PR DESCRIPTION
 - New command in doit script to package up the database on the instance
   and push it to S3.
 - Modifications to staging entrypoint to attempt to download from S3.
 - Extension to build.xml that lets us load from a /tmp/dump.sql file.

Also:
 - Ensures that we call aws CLI with --format json in case folks have a
   different default set.

#### Fixes [insert bug/issue number]
<br>

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
