### PR TITLE
Remove dotted line in Scripts sidebar.

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/node/node--script-page.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/node/node--script-page.tpl.php
@@ -37,7 +37,7 @@ hide($content['links']);
           </div>
         <?php endif; ?>
         <?php if (isset($content['field_sidebar_components'])): ?>
-          <div class="list-item foo">
+          <div class="list-item-wrapper">
             <?php print render($content['field_sidebar_components']); ?>
           </div>
         <?php endif; ?>


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov/issues/1097

#### Changes proposed in this pull request:
*  Changes Script page template to remove sidebar `list-item`
