### PR TITLE
Adds document to transaction grid to allow editors to load/link docs.

### DIFF
--- a/docroot/sites/all/modules/features/bos_component_transaction_grid/bos_component_transaction_grid.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/bos_component_transaction_grid/bos_component_transaction_grid.features.field_instance.inc
@@ -41,7 +41,7 @@ function bos_component_transaction_grid_field_default_field_instances() {
     'settings' => array(
       'add_mode' => 'button',
       'allowed_bundles' => array(
-        'document' => -1,
+        'document' => 'document',
         'external_link' => 'external_link',
         'group_of_links_grid' => -1,
         'internal_link' => 'internal_link',


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
#1129 Adds document to Transaction grid

#### Changes proposed in this pull request:
* Enables the "document" option in the transaction_link config

#### Add @mentions of the person or team responsible for reviewing proposed changes
@jimafisk 