### PR TITLE
Changes dump.sql so that Apache can delete it

### DIFF
--- a/doit
+++ b/doit
@@ -307,8 +307,9 @@ function doitstashdb() {
     if [ -f /tmp/dump.sql.gz ]; then
       doitcomment "Ungzipping"
       gunzip /tmp/dump.sql.gz
-      # Allows the Apache user to overwrite this
-      chmod a+w /tmp/dump.sql
+      # Necessary to allow the Apache user to delete this. webconsole.php runs
+      # as www-data.
+      chown www-data /tmp/dump.sql
     fi
 
     exit


### PR DESCRIPTION
Necessary for taking a new DB snapshot. The www-apache user that
webconsole.php runs as has to have permission to delete this file.
Because of the sticky bit on /tmp, that means it has to own the file.

#### Fixes [insert bug/issue number]
<br>

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
