### PR TITLE
Makes map image clickable

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--map.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--map.tpl.php
@@ -52,7 +52,11 @@
 
 <div class="b b--fw">
   <div class="ph ph--wc">
-    <div class="ph-p ph-p--<?php print $photo_id; ?>"><?php print render($content['field_image']); ?></div>
+    <a href="#<?php print $map_id; ?>">
+      <div class="ph-p ph-p--<?php print $photo_id; ?>">
+        <?php print render($content['field_image']); ?>
+      </div>
+    </a>
 
     <div class="ph-c p-a600">
       <div class="m-b200">


### PR DESCRIPTION
From usability tests, folks were trying to interact with the image of a
map. This makes it so clicking on that image pops up the modal.

#### Fixes [insert bug/issue number]
<br>

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
